### PR TITLE
ci(workflows): fix CHANGELOG extraction for version format

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -110,20 +110,24 @@ jobs:
           if (Test-Path "CHANGELOG.md") {
             $content = Get-Content "CHANGELOG.md" -Raw
 
-            # Try to extract current version's changes
-            $pattern = "## \[$version\].*?(?=## \[|\z)"
+            # Escape special regex characters in version number (dots)
+            $escapedVersion = [regex]::Escape($version)
+
+            # Try to extract current version's changes (without square brackets)
+            # Pattern: ## 2025.11.12.1 followed by content until next ## or end
+            $pattern = "(?s)## $escapedVersion\s*?\n(.*?)(?=\n## |\z)"
             if ($content -match $pattern) {
-              $notes = $Matches[0]
+              $notes = $Matches[1]
             } else {
-              # Fallback: extract from v prefix
-              $pattern = "## \[v?$version\].*?(?=## \[|\z)"
+              # Fallback: try with v prefix
+              $pattern = "(?s)## v?$escapedVersion\s*?\n(.*?)(?=\n## |\z)"
               if ($content -match $pattern) {
-                $notes = $Matches[0]
+                $notes = $Matches[1]
               } else {
-                # Fallback: use latest entry
-                $pattern = "## \[.*?\].*?(?=## \[|\z)"
+                # Fallback: use latest entry (first ## heading)
+                $pattern = "(?s)## .*?\n(.*?)(?=\n## |\z)"
                 if ($content -match $pattern) {
-                  $notes = $Matches[0]
+                  $notes = $Matches[1]
                 } else {
                   $notes = "Version $version release"
                 }
@@ -131,7 +135,6 @@ jobs:
             }
 
             # Clean up and format
-            $notes = $notes -replace '## \[.*?\]', ''
             $notes = $notes.Trim()
 
             # Write to output (escape multiline)


### PR DESCRIPTION
## 📋 變更摘要

修正 GitHub Actions workflow 的 CHANGELOG 提取邏輯，支援無方括號的版本格式。

### 主要變更

- **CI/CD 改進**: 修正 Release Notes 自動生成
  - 支援 `## 2025.11.12.1` 格式（無方括號）
  - 改進正規表達式匹配邏輯
  - 新增版本號特殊字元處理

---

## 📊 統計資訊

- **原始 Commits**: 1181 個
- **機敏 Commits**: 1180 個（已排除）
- **Squash 策略**: 合併為 1 個 commit
- **檔案變更**: 1 個
  - 修改: `.github/workflows/build-release.yml`

---

## ✅ 檢查清單

- [x] 已排除機敏檔案（.claude/, docs/, CLAUDE.md 等）
- [x] 使用 Squash Merge 簡化 history
- [x] Private repo 保留完整 commit 記錄
- [ ] 待 CI 檢查通過
- [ ] 待 Code Review

---

## ⚠️ 重要提醒

- Public repo 只包含 1 個 squash commit
- Private repo 保留完整 1181 個 commits
- 兩個 repo 的 history 完全獨立（這是正常的）
- **發布後不要從 public 拉回變更到 private**（單向流程）

---

## 🔗 相關連結

- 修正內容: 支援無方括號的 CHANGELOG 版本格式
- 技術文件：（僅私人 repo 可見）