### PR TITLE
feat: add Telegram Bot notification support

### DIFF
--- a/src/nodriver_tixcraft.py
+++ b/src/nodriver_tixcraft.py
@@ -169,6 +169,21 @@ def send_discord_notification(config_dict, stage, platform_name):
         verbose = config_dict.get("advanced", {}).get("verbose", False)
         util.send_discord_webhook_async(webhook_url, stage, platform_name, verbose=verbose)
 
+def send_telegram_notification(config_dict, stage, platform_name):
+    """Send Telegram bot notification if configured.
+
+    Args:
+        config_dict: Configuration dictionary
+        stage: "ticket" or "order"
+        platform_name: Platform name (e.g., "TixCraft", "iBon")
+    """
+    adv = config_dict.get("advanced", {})
+    bot_token = adv.get("telegram_bot_token", "")
+    chat_id = adv.get("telegram_chat_id", "")
+    if bot_token and chat_id:
+        verbose = adv.get("verbose", False)
+        util.send_telegram_message_async(bot_token, chat_id, stage, platform_name, verbose=verbose)
+
 async def nodriver_press_button(tab, select_query):
     if tab:
         try:
@@ -2851,6 +2866,7 @@ async def nodriver_kktix_main(tab, url, config_dict):
                 if config_dict["advanced"]["play_sound"]["order"]:
                     play_sound_while_ordering(config_dict)
                 send_discord_notification(config_dict, "order", "KKTIX")
+                send_telegram_notification(config_dict, "order", "KKTIX")
 
             kktix_dict["played_sound_order"] = True
 
@@ -6128,6 +6144,7 @@ async def nodriver_tixcraft_main(tab, url, config_dict, ocr, Captcha_Browser):
             if config_dict["advanced"]["play_sound"]["order"]:
                 play_sound_while_ordering(config_dict)
             send_discord_notification(config_dict, "order", "TixCraft")
+            send_telegram_notification(config_dict, "order", "TixCraft")
         tixcraft_dict["played_sound_order"] = True
     else:
         tixcraft_dict["is_popup_checkout"] = False
@@ -8051,6 +8068,7 @@ async def nodriver_ticketplus_main(tab, url, config_dict, ocr, Captcha_Browser):
                 if config_dict["advanced"]["play_sound"]["order"]:
                     play_sound_while_ordering(config_dict)
                 send_discord_notification(config_dict, "order", "TicketPlus")
+                send_telegram_notification(config_dict, "order", "TicketPlus")
 
                 try:
                     await nodriver_ticketplus_confirm(tab, config_dict)
@@ -13675,6 +13693,7 @@ async def nodriver_ibon_main(tab, url, config_dict, ocr, Captcha_Browser):
             if config_dict["advanced"]["play_sound"]["order"]:
                 play_sound_while_ordering(config_dict)
             send_discord_notification(config_dict, "order", "iBon")
+            send_telegram_notification(config_dict, "order", "iBon")
         ibon_dict["played_sound_order"] = True
 
         # If headless mode, open browser to show checkout page (only once)
@@ -14259,6 +14278,7 @@ async def nodriver_cityline_check_shopping_basket(tab, config_dict):
                     except Exception as sound_exc:
                         debug.log(f"[CITYLINE] Sound error: {sound_exc}")
                 send_discord_notification(config_dict, "order", "Cityline")
+                send_telegram_notification(config_dict, "order", "Cityline")
                 cityline_dict["played_sound_order"] = True
 
             # Return True to indicate we're on checkout page
@@ -17477,6 +17497,7 @@ async def nodriver_kham_main(tab, url, config_dict, ocr):
             if config_dict["advanced"]["play_sound"]["order"]:
                 play_sound_while_ordering(config_dict)
             send_discord_notification(config_dict, "order", "KHAM")
+            send_telegram_notification(config_dict, "order", "KHAM")
         kham_dict["played_sound_order"] = True
 
         # If headless mode, open browser to show checkout page (only once)
@@ -20649,7 +20670,8 @@ async def reload_config(config_dict, last_mtime):
                         "auto_guess_options", "user_guess_string", "auto_reload_page_interval", "verbose",
                         "auto_reload_overheat_count", "auto_reload_overheat_cd",
                         "idle_keyword", "resume_keyword", "idle_keyword_second", "resume_keyword_second",
-                        "discord_webhook_url", "discount_code"
+                        "discord_webhook_url", "telegram_bot_token", "telegram_chat_id",
+                        "discount_code"
                     ]
                     for field in adv_fields:
                         if field in new_config["advanced"]:
@@ -23220,6 +23242,7 @@ async def nodriver_hkticketing_main(tab, url, config_dict):
             if config_dict["advanced"]["play_sound"]["order"]:
                 play_sound_while_ordering(config_dict)
             send_discord_notification(config_dict, "order", "HKTicketing")
+            send_telegram_notification(config_dict, "order", "HKTicketing")
         hkticketing_dict["played_sound_order"] = True
 
         # Show message once
@@ -25070,6 +25093,7 @@ async def nodriver_funone_main(tab, url, config_dict):
                             if config_dict["advanced"]["play_sound"]["order"]:
                                 play_sound_while_ordering(config_dict)
                             send_discord_notification(config_dict, "order", "FunOne")
+                            send_telegram_notification(config_dict, "order", "FunOne")
                             funone_dict["played_sound_order"] = True
                         print("[FUNONE] Order submitted successfully!")
 
@@ -25081,6 +25105,7 @@ async def nodriver_funone_main(tab, url, config_dict):
                         if config_dict["advanced"]["play_sound"]["order"]:
                             play_sound_while_ordering(config_dict)
                         send_discord_notification(config_dict, "order", "FunOne")
+                        send_telegram_notification(config_dict, "order", "FunOne")
                         funone_dict["played_sound_order"] = True
                         print("[FUNONE] Reached fill form page - order notification sent!")
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -616,6 +616,61 @@ class TestDiscordWebhookHandler(tornado.web.RequestHandler):
             debug.log("[Discord Webhook] Test failed: %s" % str(exc))
             self.write({"success": False, "message": str(exc)})
 
+class TestTelegramHandler(tornado.web.RequestHandler):
+    def post(self):
+        try:
+            body = json.loads(self.request.body)
+        except Exception:
+            self.write({"success": False, "message": "wrong json format"})
+            return
+
+        bot_token = body.get("bot_token", "").strip()
+        chat_id = body.get("chat_id", "").strip()
+
+        if not bot_token:
+            self.write({"success": False, "message": "Bot Token is empty"})
+            return
+
+        if not chat_id:
+            self.write({"success": False, "message": "Chat ID is empty"})
+            return
+
+        chat_ids = [cid.strip() for cid in chat_id.split(",") if cid.strip()]
+        if not chat_ids:
+            self.write({"success": False, "message": "Chat ID is empty"})
+            return
+
+        _, config_dict = load_json()
+        debug = util.create_debug_logger(config_dict)
+
+        url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+        text = "[Test] Tickets Hunter Telegram test successful!"
+        errors = []
+        ok_count = 0
+        for cid in chat_ids:
+            try:
+                payload = {"chat_id": cid, "text": text}
+                response = requests.post(url, json=payload, timeout=5.0)
+                result = response.json()
+                if response.status_code == 200 and result.get("ok", False):
+                    ok_count += 1
+                else:
+                    desc = result.get("description", "HTTP %d" % response.status_code)
+                    errors.append(f"{cid}: {desc}")
+            except Exception as exc:
+                errors.append(f"{cid}: {exc}")
+
+        if ok_count == len(chat_ids):
+            debug.log("[Telegram] Test OK (%d chat(s))" % ok_count)
+            self.write({"success": True, "message": "ok"})
+        elif ok_count > 0:
+            debug.log("[Telegram] Test partial: %d/%d OK" % (ok_count, len(chat_ids)))
+            self.write({"success": True, "message": "%d/%d OK, errors: %s" % (ok_count, len(chat_ids), "; ".join(errors))})
+        else:
+            msg = "; ".join(errors)
+            debug.log("[Telegram] Test failed: %s" % msg)
+            self.write({"success": False, "message": msg})
+
 class OcrHandler(tornado.web.RequestHandler):
     def get(self):
         self.write({"answer": "1234"})
@@ -719,6 +774,7 @@ async def main_server():
         ("/reset", ResetJsonHandler),
 
         ("/test_discord_webhook", TestDiscordWebhookHandler),
+        ("/test_telegram", TestTelegramHandler),
         ("/ocr", OcrHandler),
         ("/query", QueryHandler),
         ("/question", QuestionHandler),

--- a/src/util.py
+++ b/src/util.py
@@ -2288,6 +2288,110 @@ def send_discord_webhook_async(
     thread.start()
 
 
+def build_telegram_message(stage: str, platform_name: str) -> str:
+    """
+    Build Telegram notification message text based on stage and platform.
+
+    Args:
+        stage: Notification stage ("ticket" or "order")
+        platform_name: Platform name (e.g., "TixCraft", "iBon")
+
+    Returns:
+        str: Message text
+    """
+    if not platform_name:
+        platform_name = "Unknown"
+
+    if stage == "ticket":
+        message = f"[{platform_name}] found ticket! Please check your computer"
+    elif stage == "order":
+        message = f"[{platform_name}] order success! Please checkout and pay ASAP"
+    else:
+        message = f"[{platform_name}] notification"
+
+    return message
+
+
+def send_telegram_message(
+    bot_token: str,
+    chat_id: str,
+    stage: str,
+    platform_name: str,
+    timeout: float = 3.0,
+    verbose: bool = False
+) -> bool:
+    """
+    Send Telegram Bot notification (synchronous).
+
+    Args:
+        bot_token: Telegram Bot API token
+        chat_id: Comma-separated Telegram chat IDs (e.g., "123,456")
+        stage: Notification stage ("ticket" or "order")
+        platform_name: Platform name (e.g., "TixCraft", "iBon")
+        timeout: Request timeout in seconds, default 3.0
+        verbose: Whether to print error messages
+
+    Returns:
+        bool: True if sent to at least one chat successfully, False otherwise
+    """
+    if not bot_token or not chat_id:
+        return False
+
+    chat_ids = [cid.strip() for cid in chat_id.split(",") if cid.strip()]
+    if not chat_ids:
+        return False
+
+    text = build_telegram_message(stage, platform_name)
+    url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
+    any_success = False
+    for cid in chat_ids:
+        try:
+            payload = {"chat_id": cid, "text": text}
+            response = requests.post(url, json=payload, timeout=timeout)
+            result = response.json()
+            if response.status_code == 200 and result.get("ok", False):
+                any_success = True
+            elif verbose:
+                desc = result.get("description", "HTTP %d" % response.status_code)
+                print(f"[Telegram] Send to {cid} failed: {desc}")
+        except Exception as exc:
+            if verbose:
+                print(f"[Telegram] Send to {cid} failed: {exc}")
+    return any_success
+
+
+def send_telegram_message_async(
+    bot_token: str,
+    chat_id: str,
+    stage: str,
+    platform_name: str,
+    timeout: float = 3.0,
+    verbose: bool = False
+) -> None:
+    """
+    Send Telegram Bot notification asynchronously.
+
+    Uses a daemon thread to send without blocking the main flow.
+
+    Args:
+        bot_token: Telegram Bot API token
+        chat_id: Comma-separated Telegram chat IDs (e.g., "123,456")
+        stage: Notification stage ("ticket" or "order")
+        platform_name: Platform name (e.g., "TixCraft", "iBon")
+        timeout: Request timeout in seconds, default 3.0
+        verbose: Whether to print error messages
+    """
+    if not bot_token or not chat_id:
+        return
+
+    thread = threading.Thread(
+        target=send_telegram_message,
+        args=(bot_token, chat_id, stage, platform_name, timeout, verbose),
+        daemon=True
+    )
+    thread.start()
+
+
 # Cloudflare Turnstile template paths
 def get_cf_template_paths() -> list:
     """

--- a/src/www/settings.html
+++ b/src/www/settings.html
@@ -533,6 +533,29 @@
         </div>
 
         <div class="row mb-3">
+          <label for="telegram_bot_token" class="col-sm-2 col-form-label">Telegram Bot Token
+            <span class="badge bg-secondary" data-bs-toggle="tooltip" data-bs-placement="top"
+              title="Telegram Bot API Token。透過 @BotFather 建立 Bot 後取得。留空則停用 Telegram 通知。">?</span>
+          </label>
+          <div class="col-sm-10 col-lg-8 col-xl-6">
+            <input class="form-control" id="telegram_bot_token" type="text" value="" placeholder="123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11" />
+          </div>
+        </div>
+
+        <div class="row mb-3">
+          <label for="telegram_chat_id" class="col-sm-2 col-form-label">Telegram Chat ID
+            <span class="badge bg-secondary" data-bs-toggle="tooltip" data-bs-placement="top"
+              title="Telegram 聊天室 ID，多個 ID 請用逗號隔開。可透過 @userinfobot 或 @RawDataBot 取得。">?</span>
+          </label>
+          <div class="col-sm-10 col-lg-8 col-xl-6">
+            <div class="input-group">
+              <input class="form-control" id="telegram_chat_id" type="text" value="" placeholder="123456789, 987654321" />
+              <button class="btn btn-outline-secondary" type="button" id="btn_test_telegram">測試</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="row mb-3">
           <label for="auto_reload_page_interval" class="col-sm-2 col-form-label">自動刷新頁面間隔(秒)</label>
           <div class="col-sm-10 col-lg-8 col-xl-6">
             <input class="form-control" id="auto_reload_page_interval" value="" />

--- a/src/www/settings.js
+++ b/src/www/settings.js
@@ -25,6 +25,8 @@ const play_ticket_sound = document.querySelector('#play_ticket_sound');
 const play_order_sound = document.querySelector('#play_order_sound');
 const play_sound_filename = document.querySelector('#play_sound_filename');
 const discord_webhook_url = document.querySelector('#discord_webhook_url');
+const telegram_bot_token = document.querySelector('#telegram_bot_token');
+const telegram_chat_id = document.querySelector('#telegram_chat_id');
 
 const auto_press_next_step_button = document.querySelector('#auto_press_next_step_button');
 const max_dwell_time = document.querySelector('#max_dwell_time');
@@ -205,6 +207,8 @@ function load_settins_to_form(settings)
         play_order_sound.checked = settings.advanced.play_sound.order;
         play_sound_filename.value = settings.advanced.play_sound.filename;
         discord_webhook_url.value = settings.advanced.discord_webhook_url || '';
+        telegram_bot_token.value = settings.advanced.telegram_bot_token || '';
+        telegram_chat_id.value = settings.advanced.telegram_chat_id || '';
 
         auto_press_next_step_button.checked = settings.kktix.auto_press_next_step_button;
         max_dwell_time.value = settings.kktix.max_dwell_time;
@@ -454,6 +458,8 @@ function save_changes_to_dict(silent_flag)
             settings.advanced.play_sound.order = play_order_sound.checked;
             settings.advanced.play_sound.filename = play_sound_filename.value;
             settings.advanced.discord_webhook_url = discord_webhook_url.value;
+            settings.advanced.telegram_bot_token = telegram_bot_token.value;
+            settings.advanced.telegram_chat_id = telegram_chat_id.value;
 
             settings.kktix.auto_press_next_step_button = auto_press_next_step_button.checked;
             settings.kktix.max_dwell_time = parseInt(max_dwell_time.value);
@@ -833,6 +839,46 @@ document.querySelector('#btn_test_discord_webhook').addEventListener('click', fu
         type: 'POST',
         contentType: 'application/json',
         data: JSON.stringify({ webhook_url: url }),
+        dataType: 'json'
+    })
+    .done(function(data) {
+        if (data.success) {
+            btn.className = 'btn btn-outline-success';
+            btn.textContent = 'OK';
+        } else {
+            btn.className = 'btn btn-outline-danger';
+            btn.textContent = 'Failed';
+            alert('Test failed: ' + data.message);
+        }
+    })
+    .fail(function() {
+        btn.className = 'btn btn-outline-danger';
+        btn.textContent = 'Error';
+    })
+    .always(function() {
+        setTimeout(function() {
+            btn.disabled = false;
+            btn.textContent = '\u6E2C\u8A66';
+            btn.className = 'btn btn-outline-secondary';
+        }, 3000);
+    });
+});
+
+document.querySelector('#btn_test_telegram').addEventListener('click', function() {
+    const token = telegram_bot_token.value.trim();
+    const chatId = telegram_chat_id.value.trim();
+    if (!token || !chatId) {
+        alert('Please enter both Telegram Bot Token and Chat ID first.');
+        return;
+    }
+    const btn = this;
+    btn.disabled = true;
+    btn.textContent = '...';
+    $.ajax({
+        url: '/test_telegram',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({ bot_token: token, chat_id: chatId }),
         dataType: 'json'
     })
     .done(function(data) {


### PR DESCRIPTION
Add Telegram Bot as a second notification channel alongside Discord. Users can configure bot token and multiple chat IDs (comma-separated) in the web UI settings page.

Changes:
- src/util.py: add telegram_send_message() using Telegram Bot API
- src/settings.py: add telegram_bot_token and telegram_chat_id config fields
- src/nodriver_tixcraft.py: call Telegram notification alongside Discord
- src/www/settings.html/js: add Telegram settings UI fields

## 變更摘要

<!-- 簡述這個 PR 做了什麼 -->
新增 Telegram 機器人通知的功能

## 變更類型

- [x] ✨ 新功能 (feat)
- [ ] 🐛 Bug 修復 (fix)
- [ ] ♻️ 重構 (refactor)
- [ ] 📝 文件更新 (docs)
- [ ] 🔧 維護 (chore)

## 影響平台

- [ ] TixCraft
- [ ] KKTIX
- [ ] iBon
- [ ] TicketPlus
- [ ] 其他：___
- [x] 跨平台（共用功能）

## 檢查清單

- [x] 已測試功能正常
- [x] 無敏感資訊（密碼、Cookie、API key）
- [x] `.py` 檔案中沒有使用 emoji

## 相關 Issue

Closes #
