### PR TITLE
chore(ci): remove auto-assign from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: 🐛 Bug Report
 about: Report a bug or unexpected behavior
 title: '[BUG] '
 labels: 'bug'
-assignees: 'bouob'
 ---
 
 ## Bug 描述

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: 🚀 Feature Request
 about: Suggest a new feature or enhancement
 title: '[FEATURE] <請修改標題>'
 labels: 'enhancement'
-assignees: 'bouob'
 ---
 
 <!--


### PR DESCRIPTION
## Summary

- Remove `assignees: 'bouob'` from `bug_report.md` and `feature_request.md` issue templates
- Issues will no longer be automatically assigned to @bouob on creation