### PR TITLE
fix(ibon): support new Angular Vaildate verification page

### DIFF
--- a/src/platforms/ibon.py
+++ b/src/platforms/ibon.py
@@ -3062,26 +3062,33 @@ async def nodriver_ibon_fill_verify_form(tab, config_dict, answer_list, fail_lis
             answer_1_js = json.dumps(answer_1)
             answer_2_js = json.dumps(answer_2)
 
-            # Fill both fields using JavaScript
+            # Fill both fields using JavaScript.
+            # Use the native HTMLInputElement value setter so Angular/React reactive
+            # form bindings (e.g. ngModel) see the change — assigning `.value`
+            # directly is swallowed by the framework's property override.
             fill_result_raw = await tab.evaluate(f'''
                 (function() {{
                     var inputs = document.querySelectorAll("{input_text_css}");
                     if (inputs.length >= 2) {{
                         var answer1 = {answer_1_js};
                         var answer2 = {answer_2_js};
+                        var setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+
+                        function setVal(input, value) {{
+                            setter.call(input, '');
+                            input.dispatchEvent(new Event('input', {{ bubbles: true }}));
+                            setter.call(input, value);
+                            input.dispatchEvent(new Event('input', {{ bubbles: true }}));
+                            input.dispatchEvent(new Event('change', {{ bubbles: true }}));
+                            input.dispatchEvent(new Event('blur', {{ bubbles: true }}));
+                        }}
 
                         if (inputs[0].value !== answer1) {{
-                            inputs[0].value = "";
-                            inputs[0].value = answer1;
-                            inputs[0].dispatchEvent(new Event('input', {{ bubbles: true }}));
-                            inputs[0].dispatchEvent(new Event('change', {{ bubbles: true }}));
+                            setVal(inputs[0], answer1);
                         }}
 
                         if (inputs[1].value !== answer2) {{
-                            inputs[1].value = "";
-                            inputs[1].value = answer2;
-                            inputs[1].dispatchEvent(new Event('input', {{ bubbles: true }}));
-                            inputs[1].dispatchEvent(new Event('change', {{ bubbles: true }}));
+                            setVal(inputs[1], answer2);
                         }}
 
                         return true;
@@ -3121,15 +3128,21 @@ async def nodriver_ibon_fill_verify_form(tab, config_dict, answer_list, fail_lis
             if len(inferred_answer) > 0:
                 # JSON encode for safe JavaScript string insertion
                 inferred_answer_js = json.dumps(inferred_answer)
-                # Fill the answer
+                # Fill the answer.
+                # Use the native HTMLInputElement value setter so Angular/React
+                # reactive form bindings see the change (direct `.value =` is
+                # swallowed by the framework's property override).
                 await tab.evaluate(f'''
                     (function() {{
                         var input = document.querySelector("{input_text_css}");
                         if (input) {{
-                            input.value = "";
-                            input.value = {inferred_answer_js};
+                            var setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+                            setter.call(input, '');
+                            input.dispatchEvent(new Event('input', {{ bubbles: true }}));
+                            setter.call(input, {inferred_answer_js});
                             input.dispatchEvent(new Event('input', {{ bubbles: true }}));
                             input.dispatchEvent(new Event('change', {{ bubbles: true }}));
+                            input.dispatchEvent(new Event('blur', {{ bubbles: true }}));
                         }}
                     }})()
                 ''')
@@ -3879,6 +3892,14 @@ async def nodriver_ibon_main(tab, url, config_dict, ocr, Captcha_Browser):
                             is_event_page = True
 
         if is_event_page:
+            is_enter_verify_mode = True
+            _state["fail_list"] = await nodriver_ibon_verification_question(tab, _state["fail_list"], config_dict)
+            is_match_target_feature = True
+
+    if not is_match_target_feature:
+        # New Angular SPA validation route (ibon's component is misspelled "Vaildate"):
+        # https://ticket.ibon.com.tw/Vaildate/{eventId}/{sessionId}/{activityId}
+        if 'ticket.ibon.com.tw' in url.lower() and '/vaildate/' in url.lower():
             is_enter_verify_mode = True
             _state["fail_list"] = await nodriver_ibon_verification_question(tab, _state["fail_list"], config_dict)
             is_match_target_feature = True


### PR DESCRIPTION
## 變更摘要

修復 iBon 新版 Angular 驗證頁（信用卡前 6 碼）無法自動填寫的問題。

iBon 已將驗證頁從舊版 aspx (`orders.ibon.com.tw/.../UTK02/UTK0201_0.aspx`) 遷移到新版 Angular SPA route (`ticket.ibon.com.tw/Vaildate/{eventId}/{sessionId}/{activityId}`)，原本的 URL gate 只比對舊版，導致 `nodriver_ibon_verification_question` 在新頁面從未被呼叫，使用者自定字典也不會生效。

**修改內容：**
- `src/platforms/ibon.py`：新增新版 Vaildate route 的 URL 偵測（保留舊版 aspx 分支）
- `src/platforms/ibon.py`：`nodriver_ibon_fill_verify_form` 改用原生 `HTMLInputElement` value setter，讓 Angular reactive form (`ngModel`) 能收到值（直接 `.value =` 賦值會被 framework 的 property override 吃掉，需呼叫 prototype 上的原生 setter 並 dispatch `input` event）

## 變更類型

- [ ] ✨ 新功能 (feat)
- [x] 🐛 Bug 修復 (fix)
- [ ] ♻️ 重構 (refactor)
- [ ] 📝 文件更新 (docs)
- [ ] 🔧 維護 (chore)

## 影響平台

**台灣**
- [ ] TixCraft / TicketMaster / Teamear / Indievox
- [ ] KKTIX
- [x] iBon / 年代售票
- [ ] TicketPlus
- [ ] FamiTicket
- [ ] 寬宏售票（KHAM）
- [ ] FANSI GO
- [ ] FunOne

**海外**
- [ ] Cityline 買飛
- [ ] HKTicketing 快達票

**通用**
- [ ] 跨平台共用功能（nodriver_common / util / settings）

## 檢查清單

- [x] 已測試功能正常
- [x] 無敏感資訊（密碼、Cookie、API key）
- [x] `.py` 檔案中沒有使用 emoji

## 相關 Issue

Closes #315, closes #318