### PR TITLE
fix(ibon): auto-dismiss sold-out alert on checkout page

### DIFF
--- a/src/platforms/ibon.py
+++ b/src/platforms/ibon.py
@@ -3657,13 +3657,25 @@ async def nodriver_ibon_main(tab, url, config_dict, ocr, Captcha_Browser):
         if os.path.exists(CONST_MAXBOT_INT28_FILE):
             return
 
-        # Skip checkout page - let user handle important alerts manually
-        current_url = tab.target.url if (tab and hasattr(tab, 'target') and tab.target) else ""
-        if '/utk02/utk0206_' in current_url.lower():
-            debug.log(f"[IBON ALERT] Alert on checkout page, NOT auto-dismissing: '{event.message}'")
-            return
+        msg = (getattr(event, 'message', '') or '')
+        # Use event.url (the dialog's originating URL) rather than tab.target.url;
+        # tab.target.url can be stale during navigation, while event.url is
+        # authoritative for where the dialog actually fired.
+        dialog_url = (getattr(event, 'url', '') or '').lower()
 
-        debug.log(f"[IBON ALERT] Alert detected: '{event.message}'")
+        # On checkout page, keep payment-confirmation alerts for the user to
+        # handle manually, but auto-dismiss informational sold-out notices.
+        # Without this, a sold-out alert freezes the renderer (sync dialog) and
+        # the bot can't recover — see issue #312.
+        if '/utk02/utk0206_' in dialog_url:
+            soldout_keywords = ['售完', '暫無剩餘', 'sold out']
+            msg_lower = msg.lower()
+            if not any(kw in msg or kw in msg_lower for kw in soldout_keywords):
+                debug.log(f"[IBON ALERT] Checkout alert needs confirmation, NOT auto-dismissing: '{msg}'")
+                return
+            debug.log(f"[IBON ALERT] Sold-out alert on checkout, auto-dismissing: '{msg}'")
+
+        debug.log(f"[IBON ALERT] Alert detected: '{msg}'")
 
         # Dismiss the alert - try multiple times with small delays
         for attempt in range(3):


### PR DESCRIPTION
## 變更摘要

修復 iBon 結帳頁（`/UTK02/UTK0206_*`）上的「已售完」類 alert 卡住 renderer、bot 無法繼續搶票的問題。

### 問題

`handle_ibon_alert` 原本在偵測到 URL 含 `/utk02/utk0206_` 時無條件 `return`，初衷是讓使用者親自處理 checkout 上「確認付款金額」這類重要 alert。但 iBon 的 server-side 庫存驗證失敗時，會在**同一個 URL** 觸發 informational 的 sold-out alert，例如：

- 「您選擇的數量超過剩餘可銷售數或票種已售完，請重新選擇。」
- 「已售完」
- 「暫無剩餘」

這些 alert 是 sync JavaScript dialog，會 freeze 渲染器（所有 in-page script execution 停止），bot 主迴圈無法繼續、必須使用者手動點擊「確定」才能解套 — 違背了無人值守搶票的目的。

### CDP trace 證據（attach 到正在卡住的 Chrome 蒐集）

```
[ t=2.4s] NAV  /UTK02/UTK0206_0.aspx?Buy_DateTime=202605131753
[ t=2.8s] NAV  /UTK02/UTK0206_.aspx              ← real checkout reached
[ t=4.7s] NAV  /Index/entertainment
[ t=5.1s] NAV  /ActivityInfo/Details/39590
[t=12.2s] NAV  /UTK02/UTK0206_0.aspx?Buy_DateTime=202605131753
[t=12.3s] *** Page.javascriptDialogOpening ***
          type:    alert
          message: 您選擇的數量超過剩餘可銷售數或票種已售完，請重新選擇。
          url:     orders.ibon.com.tw/.../UTK02/UTK0206_0.aspx
          hasBrowserHandler: True   ← handler 有註冊，但被 URL gate 跳過
[t=12.3s ~ 60s] renderer 完全 freeze、後續 0 events
```

之後即使使用者手動 dismiss，JS 會把使用者導回 `/UTK02/UTK0206_.aspx`（真正的結帳頁，含 06:59 倒數），但下一輪 bot 重試時又會再次卡死。

### 修法

1. 在 `/utk02/utk0206_` URL 上維持「需要使用者確認的 alert 不自動 dismiss」的原始意圖，但加上**狹窄的關鍵字白名單** `['售完', '暫無剩餘', 'sold out']`：訊息含這些字才自動 dismiss，其他（金額、付款方式、條款）維持手動處理。
2. URL 比對來源從 `tab.target.url` 改為 `event.url`：後者是 `Page.javascriptDialogOpening` 事件帶的「dialog 實際發生的 URL」，在 navigation 過渡期間更可靠。

## 變更類型

- [ ] ✨ 新功能 (feat)
- [x] 🐛 Bug 修復 (fix)
- [ ] ♻️ 重構 (refactor)
- [ ] 📝 文件更新 (docs)
- [ ] 🔧 維護 (chore)

## 影響平台

**台灣**
- [ ] TixCraft / TicketMaster / Teamear / Indievox
- [ ] KKTIX
- [x] iBon / 年代售票
- [ ] TicketPlus
- [ ] FamiTicket
- [ ] 寬宏售票（KHAM）
- [ ] FANSI GO
- [ ] FunOne

**海外**
- [ ] Cityline 買飛
- [ ] HKTicketing 快達票

**通用**
- [ ] 跨平台共用功能（nodriver_common / util / settings）

## 檢查清單

- [x] 已測試功能正常
- [x] 無敏感資訊（密碼、Cookie、API key）
- [x] `.py` 檔案中沒有使用 emoji

## 相關 Issue

Closes #312, closes #319