### PR TITLE
feat(tixcraft): add ticket_price_auto_select mode for multi-price rows

### DIFF
--- a/src/platforms/tixcraft.py
+++ b/src/platforms/tixcraft.py
@@ -2012,6 +2012,46 @@ async def nodriver_ticket_number_select_fill(tab, select_obj, ticket_number, sel
 
     return is_ticket_number_assigned
 
+CONST_TICKET_PRICE_HIGH_FIRST = "high price first"
+CONST_TICKET_PRICE_LOW_FIRST = "low price first"
+
+
+def _parse_ticket_price(name):
+    # Take the LAST digit-run. Tixcraft's <td class="fcBlue"> layout is
+    # "<name> <price>" — qty/sold-count descriptors and age modifiers
+    # ("限18+", "已售出 10000") come before the real price, never after.
+    if not isinstance(name, str) or not name:
+        return None
+    candidates = []
+    for raw in re.findall(r"\d[\d,]*", name):
+        try:
+            candidates.append(int(raw.replace(",", "")))
+        except ValueError:
+            continue
+    return candidates[-1] if candidates else None
+
+
+def _pick_ticket_by_price_mode(valid_ticket_types, mode):
+    if not valid_ticket_types:
+        return None
+
+    normalized = (mode or "").replace("_", " ").strip().lower()
+
+    if normalized in (CONST_TICKET_PRICE_HIGH_FIRST, CONST_TICKET_PRICE_LOW_FIRST):
+        priced = []
+        for t in valid_ticket_types:
+            price = _parse_ticket_price(t.get("name", ""))
+            if price is None:
+                # Any unparseable row → can't sort by price; fall back to DOM order.
+                return valid_ticket_types[0]
+            priced.append((price, t))
+        reverse = normalized == CONST_TICKET_PRICE_HIGH_FIRST
+        priced.sort(key=lambda x: x[0], reverse=reverse)
+        return priced[0][1]
+
+    return util.get_target_item_from_matched_list(valid_ticket_types, mode)
+
+
 async def nodriver_tixcraft_assign_ticket_number(tab, config_dict):
     """
     Enhanced ticket type selection with keyword matching support
@@ -2054,6 +2094,11 @@ async def nodriver_tixcraft_assign_ticket_number(tab, config_dict):
     area_keyword = config_dict["area_auto_select"]["area_keyword"].strip()
     area_auto_fallback = config_dict.get('area_auto_fallback', False)
     auto_select_mode = config_dict["area_auto_select"]["mode"]
+
+    ticket_price_mode = (
+        config_dict.get("ticket_price_auto_select", {}).get("mode")
+        or auto_select_mode
+    )
 
     # Parse keywords using JSON
     area_keyword_array = util.parse_keyword_string_to_array(area_keyword)
@@ -2209,32 +2254,19 @@ async def nodriver_tixcraft_assign_ticket_number(tab, config_dict):
         else:
             debug.log(f"[TICKET SELECT] Single option excluded by keyword_exclude: '{ticket_name}'")
 
-    # Fallback logic (similar to area selection)
+    # On the ticket page the user has already committed to an area, so a
+    # deterministic pick is always safer than stalling — keyword miss falls
+    # through to ticket_price_auto_select.mode regardless of area_auto_fallback.
     if not matched_ticket:
-        if area_keyword_array and not area_auto_fallback:
-            # Strict mode: no keyword match and fallback disabled
-            debug.log(f"[TICKET SELECT] area_auto_fallback=false, fallback is disabled")
-            debug.log(f"[TICKET SELECT] No ticket type selected")
-            return False, None, None
+        if area_keyword_array:
+            debug.log(f"[TICKET SELECT] No keyword match, using ticket_price_auto_select.mode='{ticket_price_mode}'")
         else:
-            # Fallback enabled or no keyword specified
-            if area_keyword_array:
-                debug.log(f"[TICKET SELECT] area_auto_fallback=true, using fallback selection")
+            debug.log(f"[TICKET SELECT] No keyword set, using ticket_price_auto_select.mode='{ticket_price_mode}'")
 
-            # Select based on auto_select_mode
-            matched_ticket = util.get_target_item_from_matched_list(
-                [t['select'] for t in valid_ticket_types],
-                auto_select_mode
-            )
-            # Find the ticket_info for the matched select
-            for ticket_info in valid_ticket_types:
-                if ticket_info['select'] == matched_ticket:
-                    matched_ticket = ticket_info
-                    break
+        matched_ticket = _pick_ticket_by_price_mode(valid_ticket_types, ticket_price_mode)
 
-            if matched_ticket:
-                selection_type = "fallback" if area_keyword_array else "mode-based"
-                debug.log(f"[TICKET SELECT] Selected ticket type ({selection_type}): '{matched_ticket['name']}'")
+        if matched_ticket:
+            debug.log(f"[TICKET SELECT] Selected ticket type: '{matched_ticket['name']}'")
 
     # Use the matched ticket select
     select_obj = matched_ticket['select'] if matched_ticket else None
@@ -2400,20 +2432,27 @@ async def nodriver_tixcraft_keyin_captcha_code(tab, answer="", auto_submit=False
                     await form_verifyCode.send_keys(answer)
 
                     if auto_submit:
-                        # 提交前確認票券數量是否已設定
+                        # Check ANY price-select has been assigned. On rows with
+                        # multiple price tiers, the outer picker fills only the
+                        # chosen <select>; a blind first-match would miss that
+                        # and reset both, triggering "您共選擇了 N 張".
                         ticket_number_ok = await tab.evaluate('''
                             (function() {
-                                const select = document.querySelector('.mobile-select') ||
-                                              document.querySelector('select[id*="TicketForm_ticketPrice_"]');
-                                return select && select.value !== "0" && select.value !== "";
+                                const selects = document.querySelectorAll('.mobile-select, select[id*="TicketForm_ticketPrice_"]');
+                                for (const s of selects) {
+                                    if (s.value !== "0" && s.value !== "") return true;
+                                }
+                                return false;
                             })();
                         ''')
                         ticket_number_ok = util.parse_nodriver_result(ticket_number_ok)
 
                         if not ticket_number_ok and config_dict:
                             debug.log("[TIXCRAFT CAPTCHA] Warning: Ticket number not set, resetting...")
-                            # Reset ticket number
-                            ticket_number = str(config_dict.get("ticket_number", 2))
+                            # Fallback 1 (not 2) to match line 885 and minimise the
+                            # blast radius if config is somehow missing the key.
+                            ticket_number = str(config_dict.get("ticket_number", 1))
+                            # Only fires when NO select is set; safe to fill the first one.
                             await tab.evaluate(f'''
                                 (function() {{
                                     const select = document.querySelector('.mobile-select') ||
@@ -2431,15 +2470,18 @@ async def nodriver_tixcraft_keyin_captcha_code(tab, answer="", auto_submit=False
                         # 最終確認所有欄位都已填寫
                         form_ready = await tab.evaluate('''
                             (function() {
-                                const select = document.querySelector('.mobile-select') ||
-                                              document.querySelector('select[id*="TicketForm_ticketPrice_"]');
+                                const selects = document.querySelectorAll('.mobile-select, select[id*="TicketForm_ticketPrice_"]');
+                                let anySelected = false;
+                                for (const s of selects) {
+                                    if (s.value !== "0" && s.value !== "") { anySelected = true; break; }
+                                }
                                 const verify = document.querySelector('#TicketForm_verifyCode');
                                 const agree = document.querySelector('#TicketForm_agree');
 
                                 // Ticketmaster check-captcha page has no ticket selector
                                 // Ticket number is already set on previous page
                                 const isTicketmaster = window.location.href.includes('ticketmaster');
-                                const ticketOk = isTicketmaster ? true : (select && select.value !== "0" && select.value !== "");
+                                const ticketOk = isTicketmaster ? true : anySelected;
 
                                 return {
                                     ticket: ticketOk,

--- a/src/settings.py
+++ b/src/settings.py
@@ -124,6 +124,10 @@ def get_default_config():
     config_dict["area_auto_select"]["enable"] = True
     config_dict["area_auto_select"]["mode"] = CONST_SELECT_ORDER_DEFAULT
     config_dict["area_auto_select"]["area_keyword"] = ""
+
+    config_dict["ticket_price_auto_select"] = {}
+    config_dict["ticket_price_auto_select"]["mode"] = CONST_FROM_TOP_TO_BOTTOM
+
     config_dict["keyword_exclude"] = CONST_EXCLUDE_DEFAULT
 
     config_dict['kktix']={}
@@ -271,7 +275,7 @@ def migrate_config(config_dict):
 
     # Ensure all default fields exist (fills missing keys from new versions)
     default = get_default_config()
-    for section in ["advanced", "kktix", "tixcraft", "date_auto_select", "area_auto_select", "ocr_captcha", "contact", "accounts", "cityline"]:
+    for section in ["advanced", "kktix", "tixcraft", "date_auto_select", "area_auto_select", "ticket_price_auto_select", "ocr_captcha", "contact", "accounts", "cityline"]:
         if section in default:
             if section not in config_dict or not isinstance(config_dict[section], dict):
                 config_dict[section] = dict(default[section])

--- a/src/www/help-content.js
+++ b/src/www/help-content.js
@@ -655,6 +655,40 @@ const HELP_CONTENT = {
     link: 'https://github.com/bouob/tickets_hunter/blob/main/guide/settings-guide.md#排除關鍵字'
   },
 
+  ticket_price_select_mode: {
+    title: '票種排序方式',
+    short: '同一區域有多種票價時，未匹配關鍵字則依此選擇',
+    detail: `
+      <p>當你進入訂購頁面後，若該區域同時有多種票價（例如「全票+福利兌換券 6,880」與「全票 6,800」），系統會依此設定決定要點哪一種票種，避免機器人停擺。</p>
+      <table class="table table-sm table-bordered">
+        <thead><tr><th>選項</th><th>行為</th></tr></thead>
+        <tbody>
+          <tr><td><code>from top to bottom</code></td><td>選擇列表中最上方的票種</td></tr>
+          <tr><td><code>from bottom to top</code></td><td>選擇列表中最下方的票種</td></tr>
+          <tr><td><code>center</code></td><td>選擇列表中間位置的票種（偶數則偏後一格）</td></tr>
+          <tr><td><code>random</code></td><td>隨機選擇可用票種</td></tr>
+          <tr><td><code>high price first</code></td><td>優先選擇票價較高的票種（解析票種名稱中的數字）</td></tr>
+          <tr><td><code>low price first</code></td><td>優先選擇票價較低的票種（解析票種名稱中的數字）</td></tr>
+        </tbody>
+      </table>
+      <p class="text-muted small mb-0">提示：此設定獨立於「區域自動遞補」。即使區域遞補關閉，只要已進入訂購頁面有多個票種，就會依此設定挑選，不會卡住。只有 1 種票種時不會走到這個邏輯，會直接選那唯一一個。</p>`,
+    faq: [
+      {
+        q: '為什麼需要這個設定？',
+        a: '部分拓元場次會把同一區域拆成多種票價（例如「全票」vs「全票+福利兌換券」），若沒設關鍵字，機器人需要一個明確規則來決定點哪一個，否則會卡在訂購頁。'
+      },
+      {
+        q: 'high/low price first 怎麼判斷票價？',
+        a: '抓票種名稱裡所有的連續數字、取「最後一段」當作該票種的價格 — 拓元的票種欄位永遠是「名稱在前、價格在後」的排版。範例：「全票 6,800」→ 6800；「限18+ 5,800」→ 5800（前面的 18 不算）；「已售出 10000 6,880」→ 6880（前面的 10000 不算）。任一票種沒抓到數字（例如「全票」沒寫價格）時，會放棄價格排序、改用 DOM 順序（from top to bottom）。'
+      },
+      {
+        q: 'center 在票種數為偶數時會選哪一個？',
+        a: '採 floor(N/2)，所以偶數時會「偏後一格」。例如 2 種票時選第 2 個、4 種票時選第 3 個。奇數則是真正的正中間。'
+      }
+    ],
+    link: null
+  },
+
   area_auto_fallback: {
     title: '區域自動遞補',
     short: '關鍵字全未匹配時，是否自動選擇可用區域（預設：關閉）',

--- a/src/www/settings.html
+++ b/src/www/settings.html
@@ -452,6 +452,31 @@
             </div>
           </div>
         </div>
+        <div class="row mb-3" data-under="tixcraft">
+          <label for="ticket_price_select_mode" class="col-sm-2 col-form-label">票種排序方式<span class="help-icon" data-help="ticket_price_select_mode" title="票種排序方式說明" tabindex="0" role="button" aria-label="票種排序方式 說明"></span></label>
+          <div class="col-sm-10 col-lg-8 col-xl-6">
+            <select id="ticket_price_select_mode" class="form-select" aria-label="Default select">
+              <option value="from top to bottom">
+                from top to bottom
+              </option>
+              <option value="from bottom to top">
+                from bottom to top
+              </option>
+              <option value="center">
+                center
+              </option>
+              <option value="random">
+                random
+              </option>
+              <option value="high price first">
+                high price first
+              </option>
+              <option value="low price first">
+                low price first
+              </option>
+            </select>
+          </div>
+        </div>
         <div class="row">
           <label for="keyword_exclude" class="col-sm-2 col-form-label">排除關鍵字<span class="help-icon" data-help="keyword_exclude" title="排除關鍵字說明" tabindex="0" role="button" aria-label="排除關鍵字 說明"></span>
           </label>

--- a/src/www/settings.js
+++ b/src/www/settings.js
@@ -17,6 +17,7 @@ const date_auto_fallback = document.querySelector('#date_auto_fallback');
 const area_select_mode = document.querySelector('#area_select_mode');
 const area_keyword = document.querySelector('#area_keyword');
 const area_auto_fallback = document.querySelector('#area_auto_fallback');
+const ticket_price_select_mode = document.querySelector('#ticket_price_select_mode');
 const keyword_exclude = document.querySelector('#keyword_exclude');
 
 // advance
@@ -238,6 +239,12 @@ function load_settins_to_form(settings)
         area_select_mode.value = settings.area_auto_select.mode;
         area_keyword.value = format_keyword_for_display(settings.area_auto_select.area_keyword);
         area_auto_fallback.checked = settings.area_auto_fallback || false;
+
+        if (settings.ticket_price_auto_select && settings.ticket_price_auto_select.mode) {
+            ticket_price_select_mode.value = settings.ticket_price_auto_select.mode;
+        } else {
+            ticket_price_select_mode.value = 'from top to bottom';
+        }
 
         keyword_exclude.value = format_keyword_for_display(settings.keyword_exclude);
         
@@ -496,6 +503,9 @@ function save_changes_to_dict(silent_flag)
             settings.area_auto_select.mode = area_select_mode.value;
             settings.area_auto_select.area_keyword = format_config_keyword_for_json(area_keyword.value);
             settings.area_auto_fallback = area_auto_fallback.checked;
+
+            if (!settings.ticket_price_auto_select) settings.ticket_price_auto_select = {};
+            settings.ticket_price_auto_select.mode = ticket_price_select_mode.value;
 
             settings.keyword_exclude = format_config_keyword_for_json(keyword_exclude.value);
 


### PR DESCRIPTION
## 變更摘要

拓元當「同一區域包含多個票價」時（例如 VIP 區分成「全票 6,800」與「全票+福利兌換券 6,880」），機器人會因為關鍵字未匹配而停擺。

設定頁新增「票種排序方式」下拉（位於「區域自動遞補」下方，僅 tixcraft 家族顯示），6 種模式：

- `from top to bottom`（預設）/ `from bottom to top` / `center` / `random`
- `high price first` / `low price first` — 解析票種名稱最後一段數字作為價格

獨立於 `area_auto_fallback`（訂購頁的用戶已經提交區域選擇，停擺不該是選項）。

## 變更類型

- [x] ✨ 新功能 (feat)
- [x] 🐛 Bug 修復 (fix)
- [ ] ♻️ 重構 (refactor)
- [ ] 📝 文件更新 (docs)
- [ ] 🔧 維護 (chore)

## 影響平台

- [x] TixCraft
- [ ] KKTIX
- [ ] iBon
- [ ] TicketPlus
- [ ] 其他：___
- [ ] 跨平台（共用功能）

## 檢查清單

- [x] 已測試功能正常（真實 DOM 驗證 + 設定頁 round-trip）
- [x] 無敏感資訊（密碼、Cookie、API key）
- [x] `.py` 檔案中沒有使用 emoji

## 相關 Issue

Closes #309
Related to #38 — 本 PR 解決「選哪個票種」的部分；#38 另外提到的「每個票種各買幾張」不在本 PR 範圍。