### PR TITLE
fix(platforms): update URL segment checks to handle trailing slashes

### DIFF
--- a/src/platforms/hkticketing.py
+++ b/src/platforms/hkticketing.py
@@ -2681,7 +2681,7 @@ async def nodriver_hkticketing_main(tab, url, config_dict):
             debug.log("[HKTICKETING] Modal dialog popup, skip...")
         else:
             is_event_page = False
-            if len(url.split('/')) == 5:
+            if len(url.rstrip('/').split('/')) == 5:
                 is_event_page = True
 
             if is_event_page:

--- a/src/platforms/ibon.py
+++ b/src/platforms/ibon.py
@@ -3993,7 +3993,7 @@ async def nodriver_ibon_main(tab, url, config_dict, ocr, Captcha_Browser):
         #https://ticket.ibon.com.tw/ActivityInfo/Details/0000?pattern=entertainment
         if '/activityinfo/details/' in url.lower():
             is_event_page = False
-            if len(url.split('/'))==6:
+            if len(url.rstrip('/').split('/'))==6:
                 is_event_page = True
 
             if is_event_page:
@@ -4060,13 +4060,13 @@ async def nodriver_ibon_main(tab, url, config_dict, ocr, Captcha_Browser):
         if '/UTK02/UTK0201_' in url.upper():
             if '.aspx?' in url.lower():
                 if 'PERFORMANCE_ID=' in url.upper():
-                    if len(url.split('/'))==6:
+                    if len(url.rstrip('/').split('/'))==6:
                         is_event_page = True
 
         if '/UTK02/UTK0202_' in url.upper():
             if '.aspx?' in url.lower():
                 if 'PERFORMANCE_ID=' in url.upper():
-                    if len(url.split('/'))==6:
+                    if len(url.rstrip('/').split('/'))==6:
                         is_event_page = True
 
         if is_event_page:
@@ -4627,13 +4627,13 @@ async def nodriver_ibon_main(tab, url, config_dict, ocr, Captcha_Browser):
         if '/UTK02/UTK0201_' in url.upper():
             if '.aspx?' in url.lower():
                 if 'PERFORMANCE_ID=' in url.upper():
-                    if len(url.split('/'))==6:
+                    if len(url.rstrip('/').split('/'))==6:
                         is_event_page = True
 
         if '/UTK02/UTK0202_' in url.upper():
             if '.aspx?' in url.lower():
                 if 'PERFORMANCE_ID=' in url.upper():
-                    if len(url.split('/'))==6:
+                    if len(url.rstrip('/').split('/'))==6:
                         is_event_page = True
 
         if is_event_page:
@@ -4774,7 +4774,7 @@ async def nodriver_ibon_main(tab, url, config_dict, ocr, Captcha_Browser):
         is_event_page = False
         if '/UTK02/UTK020' in url.upper():
             if '.aspx' in url.lower():
-                if len(url.split('/'))==6:
+                if len(url.rstrip('/').split('/'))==6:
                     is_event_page = True
 
         # ignore "pay money" step.

--- a/src/platforms/kham.py
+++ b/src/platforms/kham.py
@@ -1694,7 +1694,7 @@ async def nodriver_kham_main(tab, url, config_dict, ocr):
 
     # Product page (UTK0201_.aspx?product_id=)
     if 'utk0201_.aspx?product_id=' in url.lower():
-        is_event_page = len(url.split('/')) == 6
+        is_event_page = len(url.rstrip('/').split('/')) == 6
 
         if is_event_page:
             # Check realname dialog
@@ -1753,7 +1753,7 @@ async def nodriver_kham_main(tab, url, config_dict, ocr):
 
     # Date selection page (UTK0201_00.aspx?product_id=)
     if 'utk0201_00.aspx?product_id=' in url.lower():
-        is_event_page = len(url.split('/')) == 6
+        is_event_page = len(url.rstrip('/').split('/')) == 6
 
         if is_event_page and config_dict["date_auto_select"]["enable"]:
             await nodriver_kham_product(tab, domain_name, config_dict)

--- a/src/platforms/kktix.py
+++ b/src/platforms/kktix.py
@@ -2136,7 +2136,7 @@ async def nodriver_kktix_main(tab, url, config_dict):
             is_event_page = False
             if '/events/' in url:
                 # ex: https://xxx.kktix.cc/events/xxx-copy-1
-                if len(url.split('/'))<=5:
+                if len(url.rstrip('/').split('/'))<=5:
                     is_event_page = True
 
             if is_event_page:

--- a/src/platforms/ticketplus.py
+++ b/src/platforms/ticketplus.py
@@ -1749,7 +1749,7 @@ async def nodriver_ticketplus_main(tab, url, config_dict, ocr, Captcha_Browser):
     # https://ticketplus.com.tw/activity/XXX
     if '/activity/' in url.lower():
         is_event_page = False
-        if len(url.split('/'))==5:
+        if len(url.rstrip('/').split('/'))==5:
             is_event_page = True
 
         if is_event_page:
@@ -1768,7 +1768,7 @@ async def nodriver_ticketplus_main(tab, url, config_dict, ocr, Captcha_Browser):
     # https://ticketplus.com.tw/order/XXX/OOO
     if '/order/' in url.lower():
         is_event_page = False
-        if len(url.split('/'))==6:
+        if len(url.rstrip('/').split('/'))==6:
             is_event_page = True
 
         if is_event_page:
@@ -1821,7 +1821,7 @@ async def nodriver_ticketplus_main(tab, url, config_dict, ocr, Captcha_Browser):
     # https://ticketplus.com.tw/confirmseat/xx/oo
     if '/confirm/' in url.lower() or '/confirmseat/' in url.lower():
         is_event_page = False
-        if len(url.split('/'))==6:
+        if len(url.rstrip('/').split('/'))==6:
             is_event_page = True
 
         if is_event_page:

--- a/src/platforms/tixcraft.py
+++ b/src/platforms/tixcraft.py
@@ -3201,7 +3201,7 @@ async def nodriver_tixcraft_main(tab, url, config_dict, ocr, Captcha_Browser):
     # - /activity/game/{event_id} (event date listing page from /activity/detail redirect)
     is_ticketmaster_date_page = (
         'ticketmaster' in url and
-        (('/artist/' in url and len(url.split('/'))==6) or
+        (('/artist/' in url and len(url.rstrip('/').split('/'))==6) or
          ('/activity/game/' in url))
     )
 

--- a/src/www/settings.html
+++ b/src/www/settings.html
@@ -904,7 +904,7 @@
           </div>
         </div>
 
-        <div class="row mb-3" data-under="tixcraft kktix">
+        <div class="row mb-3" data-under="tixcraft">
           <label for="facebook_account" class="col-sm-2 col-form-label">Facebook</label>
           <div class="col-sm-10 col-lg-8 col-xl-6">
             <form autocomplete="off">


### PR DESCRIPTION
## 變更摘要

修正了路徑字串分割時遇到的尾隨斜線（trailing slash）判斷錯誤。

- 改變：針對所有類似的判斷式，將原本的 `len(url.split('/')) == N`，修改為使用 `url.rstrip('/')` 清除尾隨斜線後再進行分割。
- 目標：確保無論網址結尾是否有 `/`，路徑區段（segments）的計數都準確無誤。

此外，針對 kktix 平台修正了介面顯示問題：
- 修正 Facebook 登入的展示代碼，因為 kktix 並不支援該登入方式。

## 變更類型

- [ ] ✨ 新功能 (feat)
- [x] 🐛 Bug 修復 (fix)
- [ ] ♻️ 重構 (refactor)
- [ ] 📝 文件更新 (docs)
- [ ] 🔧 維護 (chore)

## 影響平台

**台灣**
- [x] TixCraft / TicketMaster / Teamear / Indievox
- [x] KKTIX
- [x] iBon / 年代售票
- [x] TicketPlus
- [ ] FamiTicket
- [x] 寬宏售票（KHAM）
- [ ] FANSI GO
- [ ] FunOne

**海外**
- [ ] Cityline 買飛
- [x] HKTicketing 快達票

**通用**
- [ ] 跨平台共用功能（nodriver_common / util / settings）

## 檢查清單

- [x] 已測試功能正常
- [x] 無敏感資訊（密碼、Cookie、API key）
- [x] `.py` 檔案中沒有使用 emoji

## 相關 Issue

Closes #354 #308