### PR TITLE
Remove unused `auto_reload_overheat_count` and `auto_reload_overheat_cd` parameters

### DIFF
--- a/src/nodriver_tixcraft.py
+++ b/src/nodriver_tixcraft.py
@@ -624,7 +624,6 @@ async def reload_config(config_dict, last_mtime, config_filepath):
                         "play_sound", "disable_adjacent_seat", "hide_some_image",
                         "auto_guess_options", "user_guess_string", "auto_reload_page_interval", "verbose",
                         "tixcraft_soft_block_delay",
-                        "auto_reload_overheat_count", "auto_reload_overheat_cd",
                         "idle_keyword", "resume_keyword", "idle_keyword_second", "resume_keyword_second",
                         "discord_webhook_url", "telegram_bot_token", "telegram_chat_id",
                         "discount_code"

--- a/src/settings.py
+++ b/src/settings.py
@@ -252,8 +252,6 @@ def get_default_config():
 
     config_dict["advanced"]["auto_reload_page_interval"] = 5
     config_dict["advanced"]["tixcraft_soft_block_delay"] = ""
-    config_dict["advanced"]["auto_reload_overheat_count"] = 4
-    config_dict["advanced"]["auto_reload_overheat_cd"] = 1.0
     config_dict["advanced"]["reset_browser_interval"] = 0
     config_dict["advanced"]["proxy_server_port"] = ""
     config_dict["advanced"]["window_size"] = "600,1024"


### PR DESCRIPTION


## 變更摘要

Removing them from:
- settings.py: get_default_config()
- nodriver_tixcraft.py: reload_config() adv_fields whitelist


## 變更類型

- [ ] ✨ 新功能 (feat)
- [x] 🐛 Bug 修復 (fix)
- [ ] ♻️ 重構 (refactor)
- [ ] 📝 文件更新 (docs)
- [ ] 🔧 維護 (chore)

## 影響平台

**台灣**
- [ ] TixCraft / TicketMaster / Teamear / Indievox
- [ ] KKTIX
- [ ] iBon / 年代售票
- [ ] TicketPlus
- [ ] FamiTicket
- [ ] 寬宏售票（KHAM）
- [ ] FANSI GO
- [ ] FunOne

**海外**
- [ ] Cityline 買飛
- [ ] HKTicketing 快達票

**通用**
- [x] 跨平台共用功能（nodriver_common / util / settings）

## 檢查清單

- [x] 已測試功能正常
- [x] 無敏感資訊（密碼、Cookie、API key）
- [x] `.py` 檔案中沒有使用 emoji

## 相關 Issue

Closes #
