### PR TITLE
fix: repair broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ tickets_hunter/
 ---
 
 ## ⭐ Star History
-<a href="https://www.star-history.com/#bouob/tickets_hunter&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#bouob/tickets_hunter&type=date&legend=top-left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=bouob/tickets_hunter&type=Date&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=bouob/tickets_hunter&type=Date&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=bouob/tickets_hunter&type=Date&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=bouob/tickets_hunter&type=Date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=bouob/tickets_hunter&type=Date&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=bouob/tickets_hunter&type=Date&legend=top-left" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart shown on the README is currently broken and no longer renders correctly. This change points it to a working service so the chart displays again as expected.