### PR TITLE
style(ui): pin settings action buttons and header, and color-code them

### DIFF
--- a/src/www/css/settings.css
+++ b/src/www/css/settings.css
@@ -10,6 +10,8 @@
 body {
 	margin: 36px;
 	font-family: 'jf-openhuninn', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+	/* Reserve room for the fixed .action-bar so it never covers the last form row */
+	padding-bottom: var(--action-bar-height, 80px);
 }
 
 textarea {
@@ -243,4 +245,76 @@ textarea {
 }
 [data-bs-theme="dark"] #helpPanel code {
     background-color: var(--bs-tertiary-bg, #2b3035);
+}
+
+/* --- Sticky Action Bar (fixed to viewport bottom) --- */
+/* 搶票 / 存檔 / 重設 / 結束 pinned to the viewport bottom so scrolling through
+   the long settings form never hides them. z-index stays below Bootstrap's
+   offcanvas (1045) and modal (1055) so overlays still win. */
+.action-bar {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1030;
+    padding: 0.75rem 36px;
+    background-color: var(--bs-body-bg);
+    border-top: 1px solid var(--bs-border-color);
+    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.action-bar-inner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+[data-bs-theme="dark"] .action-bar {
+    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.4);
+}
+
+/* --- Sticky Header (profile bar + tab nav, pinned to viewport top) --- */
+/* Instance profile bar + tab nav pinned to the viewport top, so switching
+   profiles or tabs never requires scrolling back up. Sits below the
+   .action-bar (1030) and Bootstrap's offcanvas (1045) / modal (1055). */
+.sticky-header {
+    position: sticky;
+    top: 0;
+    z-index: 1020;
+    padding-top: 0.75rem;
+    background-color: var(--bs-body-bg);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
+}
+
+/* The tab nav's own bottom border doubles as the header's edge */
+.sticky-header #myTab {
+    margin-bottom: 0;
+}
+
+[data-bs-theme="dark"] .sticky-header {
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+}
+
+/* Narrow viewports: match the tighter gutter and allow the buttons to wrap */
+@media (max-width: 575.98px) {
+    .action-bar {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+    body {
+        --action-bar-height: 124px;
+    }
+}
+
+/* 存檔 button: a slightly lighter blue than the other primary buttons so the
+   most-frequently-used action is easy to spot. Overriding Bootstrap's per-button
+   CSS variables keeps hover/active/focus states consistent and theme-aware. */
+#save_btn {
+    --bs-btn-bg: #4d94ff;
+    --bs-btn-border-color: #4d94ff;
+    --bs-btn-hover-bg: #3d86f5;
+    --bs-btn-hover-border-color: #3d86f5;
+    --bs-btn-active-bg: #3d86f5;
+    --bs-btn-active-border-color: #3d86f5;
 }

--- a/src/www/settings.html
+++ b/src/www/settings.html
@@ -94,6 +94,8 @@
   <div class="container py-4">
   <div id="message"></div>
   <h2 id="page_title">Tickets Hunter <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="currentColor" class="bi bi-ticket-perforated" viewBox="0 0 16 16" style="vertical-align: -0.125em;"><path d="M4 4.85v.9h1v-.9zm7 0v.9h1v-.9zm-7 1.8v.9h1v-.9zm7 0v.9h1v-.9zm-7 1.8v.9h1v-.9zm7 0v.9h1v-.9zm-7 1.8v.9h1v-.9zm7 0v.9h1v-.9z"/><path d="M1.5 3A1.5 1.5 0 0 0 0 4.5V6a.5.5 0 0 0 .5.5 1.5 1.5 0 1 1 0 3 .5.5 0 0 0-.5.5v1.5A1.5 1.5 0 0 0 1.5 13h13a1.5 1.5 0 0 0 1.5-1.5V10a.5.5 0 0 0-.5-.5 1.5 1.5 0 0 1 0-3A.5.5 0 0 0 16 6V4.5A1.5 1.5 0 0 0 14.5 3zM1 4.5a.5.5 0 0 1 .5-.5h13a.5.5 0 0 1 .5.5v1.05a2.5 2.5 0 0 0 0 4.9v1.05a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5v-1.05a2.5 2.5 0 0 0 0-4.9z"/></svg> - 多平台搶票自動化系統</h2>
+  <!-- Sticky header: profile bar + tab nav stay visible while scrolling the long form -->
+  <div class="sticky-header" id="sticky_header">
   <!-- Instance profile bar: one pill per profile (= one bot instance config) -->
   <div class="d-flex align-items-center flex-wrap mb-2" id="profile_bar">
     <span class="me-2 text-muted small">實例設定檔：</span>
@@ -102,7 +104,6 @@
             onclick="show_profile_modal()" title="新增實例設定檔（選擇平台）">＋ 新增</button>
     <span id="profile_warnings" class="d-flex flex-wrap gap-1 ms-2"></span>
   </div>
-  <div class="row g-3">
     <ul class="nav nav-tabs" id="myTab" role="tablist">
       <li class="nav-item" role="presentation">
         <button class="nav-link active" id="readme-tab" data-bs-toggle="tab" data-bs-target="#readme-tab-pane" type="button" role="tab" aria-controls="readme-tab-pane" aria-selected="true">使用需知</button>
@@ -154,6 +155,9 @@
         </div>
       </li>
     </ul>
+  </div>
+
+  <div class="row g-3">
     <div class="tab-content" id="myTabContent">
       <!-- tab 1 -->
       <div class="tab-pane fade show active" id="readme-tab-pane" role="tabpanel" aria-labelledby="readme-tab" tabindex="0">
@@ -1210,17 +1214,19 @@
       </div>
 
     </div>
-    <hr/>
-    <div class="col-12">
+  </div>
+  </div>
+
+  <!-- Sticky action bar: fixed to the viewport bottom so the four primary
+       actions stay reachable at any scroll position -->
+  <div class="action-bar" id="action_bar">
+    <div class="action-bar-inner">
       <button class="btn btn-primary" id="run_btn">搶票</button>
       <button class="btn btn-primary" id="save_btn">存檔</button>
-      <button class="btn btn-primary" id="reset_btn">重設為預設值</button>
+      <button class="btn btn-warning" id="reset_btn">重設為預設值</button>
       <button class="btn btn-danger" id="exit_btn">結束</button>
-    </div>
-    <div class="col-12">
       <span class="text-danger" id="run_btn_pressed_message"></span>
     </div>
-  </div>
   </div>
 
 <div class="modal" id="profile_modal" tabindex="-1" role="dialog">


### PR DESCRIPTION
The long settings form pushed both the top navigation and the bottom action buttons out of view while scrolling, so saving frequently or switching profiles meant scrolling back and forth.

- Fixed bottom action bar (搶票/存檔/重設/結束) that stays at the viewport bottom at any scroll position; body gets bottom padding so it never covers the last form row.
- Sticky top header (instance profile bar + tab nav) so switching profiles or tabs no longer needs scrolling back up.
- 存檔 gets a slightly lighter blue and 重設 switches to btn-warning so the four actions are quicker to tell apart.

Colors use Bootstrap CSS variables (theme-aware); both bars sit below Bootstrap's offcanvas/modal z-index so overlays still win.

## 變更摘要

設定頁的表單很長，捲動時上方的實例設定檔列與分頁導覽、下方的四顆操作按鈕都會離開視野，頻繁存檔或切換設定檔就得來回捲動。

此 PR 將兩者固定在視窗上下緣，並調整四顆按鈕的配色讓它們更容易區分。僅變更 `src/www/css/settings.css` 與 `src/www/settings.html`，不含任何 Python，也不影響設定頁以外的行為。

依 CONTRIBUTING.md，commit type 為 `style`（UI/樣式）；下方分類沒有對應項目，故勾選最接近的一項。


## 變更類型

- [x] ✨ 新功能 (feat)
- [ ] 🐛 Bug 修復 (fix)
- [ ] ♻️ 重構 (refactor)
- [ ] 📝 文件更新 (docs)
- [ ] 🔧 維護 (chore)

## 影響平台

**台灣**
- [ ] TixCraft / TicketMaster / Teamear / Indievox
- [ ] KKTIX
- [ ] iBon / 年代售票
- [ ] TicketPlus
- [ ] FamiTicket
- [ ] 寬宏售票（KHAM）
- [ ] FANSI GO
- [ ] FunOne

**海外**
- [ ] Cityline 買飛
- [ ] HKTicketing 快達票

**通用**
- [x] 跨平台共用功能（nodriver_common / util / settings）

## 檢查清單

測試方式：以本機 Tornado server 載入 settings.html（深色主題、8 個實例設定檔），捲動整頁確認上下兩列維持固定、最後一列表單未被遮住。

- [x] 已測試功能正常
- [x] 無敏感資訊（密碼、Cookie、API key）
- [x] `.py` 檔案中沒有使用 emoji（本 PR 不含 .py 變更）

## 相關 Issue

無。
