### PR TITLE
feat(instance): label browser windows with their instance id

### DIFF
--- a/src/nodriver_common.py
+++ b/src/nodriver_common.py
@@ -993,6 +993,100 @@ async def with_pause_check(task_func, config_dict, *args, **kwargs):
     return await task
 
 
+# Targets that already carry the persistent instance-label script, so the
+# CDP registration is not repeated on every main-loop pass.
+_instance_label_targets = set()
+
+
+def _build_instance_label_js(instance_id):
+    """JS that marks a page with the instance id.
+
+    Runs at document-start via Page.addScriptToEvaluateOnNewDocument, so it is
+    in place before the page's own scripts. Only an on-page badge is drawn:
+    document.title is deliberately left alone so the site sees exactly the
+    title it wrote, and no MutationObserver has to run on a page that
+    refreshes as often as a ticket page does.
+    """
+    return """
+    (function() {
+        var id = %s;
+
+        function stampBadge() {
+            try {
+                if (!document.body) { return; }
+                var badge = document.getElementById('__th_instance_badge');
+                if (!badge) {
+                    var hue = 0;
+                    for (var i = 0; i < id.length; i++) {
+                        hue = (hue * 31 + id.charCodeAt(i)) %% 360;
+                    }
+                    badge = document.createElement('div');
+                    badge.id = '__th_instance_badge';
+                    badge.style.cssText = [
+                        'position:fixed', 'left:8px', 'bottom:8px',
+                        'z-index:2147483647', 'pointer-events:none',
+                        'background:hsl(' + hue + ',65%%,38%%)', 'color:#fff',
+                        'font:600 13px/1.4 system-ui,sans-serif',
+                        'padding:4px 10px', 'border-radius:6px', 'opacity:0.85',
+                        'box-shadow:0 1px 4px rgba(0,0,0,0.4)'
+                    ].join(';');
+                    document.body.appendChild(badge);
+                }
+                badge.textContent = id;
+            } catch (e) {}
+        }
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', stampBadge);
+        } else {
+            stampBadge();
+        }
+        window.addEventListener('load', stampBadge);
+    })()
+    """ % json.dumps(instance_id)
+
+
+async def nodriver_install_instance_label(tab, config_dict=None):
+    """Make multi-instance browser windows tellable apart.
+
+    Registers a document-start script that pins a small colored badge, whose
+    text is the instance id and whose hue is derived from it, to the bottom
+    left corner. Registration is per target and survives navigation, so no
+    polling is needed to keep the badge in place.
+
+    The badge is pointer-events:none, so it can never intercept a click the
+    bot is trying to make. Labeling is cosmetic: every failure is swallowed
+    rather than allowed to disturb the main loop.
+    """
+    if tab is None:
+        return
+
+    target_id = None
+    try:
+        target_id = tab.target.target_id
+    except Exception:
+        pass
+    if target_id is not None and target_id in _instance_label_targets:
+        return
+
+    label_js = _build_instance_label_js(util.get_instance_id())
+    try:
+        # Page.enable is required: without it the browser accepts the
+        # addScriptToEvaluateOnNewDocument call but never runs the script on
+        # subsequent documents, so the label would vanish on the first
+        # navigation.
+        await asyncio.wait_for(tab.send(cdp.page.enable()), timeout=5.0)
+        await asyncio.wait_for(
+            tab.send(cdp.page.add_script_to_evaluate_on_new_document(
+                source=label_js, run_immediately=True)),
+            timeout=5.0,
+        )
+        if target_id is not None:
+            _instance_label_targets.add(target_id)
+    except Exception:
+        pass
+
+
 # ===== Browser Initialization =====
 
 def get_nodriver_browser_args():

--- a/src/nodriver_tixcraft.py
+++ b/src/nodriver_tixcraft.py
@@ -766,6 +766,10 @@ async def main(args):
     heartbeat_interval_sec = 5
     heartbeat_filename = "heartbeat.txt"
     last_heartbeat_time = 0.0
+    # Cheap re-check that the current target carries the instance label; the
+    # label itself persists across navigation via a document-start script.
+    instance_label_interval_sec = 2
+    last_instance_label_time = 0.0
     last_empty_url_log = 0.0  # [URL DIAG] Step 0: throttle empty-url diagnostics
     is_quit_bot = False
     refresh_datetime_state = {
@@ -798,6 +802,14 @@ async def main(args):
                     heartbeat_file.write(str(int(heartbeat_now)))
             except Exception:
                 pass
+
+        # Register the instance label on this target. The injected script is
+        # what keeps the mark alive across navigation; this call only covers
+        # the case where the flow moved to a different tab, and returns
+        # immediately once a target is already registered.
+        if heartbeat_now - last_instance_label_time >= instance_label_interval_sec:
+            last_instance_label_time = heartbeat_now
+            await nodriver_install_instance_label(tab, config_dict)
 
         # pass if driver not loaded.
         if driver is None:


### PR DESCRIPTION
Running several instances at once gave identical-looking browser windows with no way to tell which one belonged to which profile.

Register a document-start script per target that pins a small badge to the bottom left corner, showing the instance id in a color derived from it. Page.enable has to precede addScriptToEvaluateOnNewDocument: without it the browser accepts the registration but never runs the script on later documents, so the badge would survive only until the first navigation.

document.title is left untouched. Prefixing it would show up in the taskbar too, but it also changes what every page-title check sees -- ibon's Cloudflare detection compares the title exactly -- and it needs a MutationObserver to survive SPA route changes. On a page that refreshes as often as a ticket page that is a cost with no upper bound, and the badge alone already tells the windows apart.

The badge is pointer-events:none so it can never intercept a click, and every failure in the labeling path is swallowed rather than allowed to disturb the main loop. Registration is tracked per target id, so the per-loop call returns immediately once a target is already labeled.


Claude-Session: https://claude.ai/code/session_01QauGPFuvvde9NHEYxXKtMf

## 變更摘要

多開時每個瀏覽器視窗長得一模一樣，無法分辨哪一個對應哪一個設定檔。

此 PR 以 document-start 腳本在每個頁面左下角釘一個小徽章，內容是實例 id，底色由 id 推導，所以不同實例顏色不同。`document.title` 刻意不動 —— 加前綴雖然在工作列也看得到，但那會改變所有讀取頁面標題的程式看到的字串（iBon 的 Cloudflare 偵測就是用完全比對），而且需要 MutationObserver 才能在 SPA 換頁後存活；在一個不斷重整的搶票頁上，那是沒有上限的成本。徽章本身已經足以分辨視窗。

**對主迴圈的影響**：註冊以 target id 記錄，同一個 target 只做一次；主迴圈中的呼叫節流為每 2 秒一次，且在已註冊的情況下立刻返回。徽章為 `pointer-events: none`，不可能攔截到 bot 要點的元素。標示屬於裝飾性功能，該路徑上的所有例外都被吞掉，不會干擾主迴圈。

僅新增 106 行、**0 行刪除**，不修改任何既有函式，不動任何平台模組。


## 變更類型

- [x] ✨ 新功能 (feat)
- [ ] 🐛 Bug 修復 (fix)
- [ ] ♻️ 重構 (refactor)
- [ ] 📝 文件更新 (docs)
- [ ] 🔧 維護 (chore)

## 影響平台

**台灣**
- [ ] TixCraft / TicketMaster / Teamear / Indievox
- [ ] KKTIX
- [ ] iBon / 年代售票
- [ ] TicketPlus
- [ ] FamiTicket
- [ ] 寬宏售票（KHAM）
- [ ] FANSI GO
- [ ] FunOne

**海外**
- [ ] Cityline 買飛
- [ ] HKTicketing 快達票

**通用**
- [x] 跨平台共用功能（nodriver_common / util / settings）

## 檢查清單

測試方式：將 `_build_instance_label_js()` 產出的腳本注入頁面，確認徽章出現於左下角、文字等於實例 id、`position:fixed`、`pointer-events:none`、`z-index:2147483647`、底色由 id 推導，且 `document.title` 未被改動。

- [x] 已測試功能正常
- [x] 無敏感資訊（密碼、Cookie、API key）
- [x] `.py` 檔案中沒有使用 emoji

## 相關 Issue

無。
