### PR TITLE
fix(ticketplus): restore automatic dismissal of failure dialogs

### DIFF
--- a/src/platforms/ticketplus.py
+++ b/src/platforms/ticketplus.py
@@ -1284,9 +1284,21 @@ async def nodriver_ticketplus_accept_order_fail(tab, debug=None):
                     'OK',
                     'Ok'
                 ];
+                // .v-dialog__content is position:fixed, so its offsetParent is
+                // always null whether or not the dialog shows. rect + computed
+                // style is the only visibility test valid for every wrapper.
+                const isVisible = (el) => {
+                    const rect = el.getBoundingClientRect();
+                    if (!rect.width || !rect.height) return false;
+                    const style = window.getComputedStyle(el);
+                    return style.display !== 'none' &&
+                           style.visibility !== 'hidden' &&
+                           style.opacity !== '0';
+                };
+
                 const dialogs = document.querySelectorAll('[role="dialog"], .v-dialog, .v-dialog__content');
                 for (const dialog of dialogs) {
-                    if (dialog.offsetParent === null) continue;
+                    if (!isVisible(dialog)) continue;
                     const text = (dialog.textContent || '').trim();
                     if (!failureTexts.some(t => text.includes(t))) continue;
                     const buttons = dialog.querySelectorAll('button');
@@ -1350,11 +1362,31 @@ async def nodriver_ticketplus_check_queue_status(tab, config_dict, force_show_de
 
                 const hasQueueKeyword = queueKeywords.some(keyword => bodyText.includes(keyword));
 
-                const dialogText = document.querySelector('.v-dialog')?.textContent || '';
-                const hasFailureDialog = failureKeywords.some(keyword => dialogText.includes(keyword));
+                // Vuetify keeps every dialog mounted, so querySelector('.v-dialog')
+                // usually returns an inactive empty node and the failure veto below
+                // never fires -- which is how the failure popup got read as a queue
+                // in the first place (#389). Scan every *visible* dialog instead.
+                const isVisible = (el) => {
+                    const rect = el.getBoundingClientRect();
+                    if (!rect.width || !rect.height) return false;
+                    const style = window.getComputedStyle(el);
+                    return style.display !== 'none' &&
+                           style.visibility !== 'hidden' &&
+                           style.opacity !== '0';
+                };
+
+                const dialogTexts = Array.from(document.querySelectorAll('.v-dialog, [role="dialog"]'))
+                    .filter(isVisible)
+                    .map(el => (el.textContent || '').trim())
+                    .filter(text => text.length > 0);
+
+                const dialogText = dialogTexts.join(' | ');
+                const hasFailureDialog = dialogTexts.some(text =>
+                    failureKeywords.some(keyword => text.includes(keyword)));
                 const hasQueueDialog = !hasFailureDialog &&
-                                       (dialogText.includes('\u6392\u968a') ||
-                                        dialogText.includes('\u8acb\u7a0d\u5019'));
+                                       dialogTexts.some(text =>
+                                           text.includes('\u6392\u968a') ||
+                                           text.includes('\u8acb\u7a0d\u5019'));
 
                 // A bare scrim is NOT a queue: every Vuetify dialog and loading
                 // mask draws one, so the order-failure popup used to be read as
@@ -1481,27 +1513,36 @@ async def _ticketplus_wait_after_submit(tab, config_dict, debug):
 async def _ticketplus_monitor_queue(tab, config_dict, debug):
     """Watch the in-page queue until it clears, moves on, or the order fails.
 
-    The queue re-check keeps its randomized 5-10s cadence, but the URL is polled
-    every CONST_TICKETPLUS_QUEUE_URL_POLL_INTERVAL seconds and the failure popup
-    is checked each round, so neither has to wait out a full cycle.
+    The queue re-check keeps its randomized 5-10s cadence (anti-detection), but
+    the URL *and* the failure popup are polled every
+    CONST_TICKETPLUS_QUEUE_URL_POLL_INTERVAL seconds. Reading the popup out of the
+    local DOM sends no request, so it must not be rate-limited with the queue
+    check: doing so left the modal on screen for the whole randomized window
+    (5-10s, ~7.5s average) while it blocked every click on the page.
 
     Gives up after CONST_TICKETPLUS_QUEUE_MONITOR_MAX: removing the scrim signal
     fixed the popup that caused #389, but an unbounded loop would strand the bot
     all the same the next time a dialog happens to carry queue wording.
+
+    Returns:
+        "confirmed"  -- confirmation page reached
+        "order_fail" -- failure popup detected (dismissed if possible)
+        "queue_end"  -- queue wording gone, resume normal page processing
+        "timeout"    -- monitor fuse blew, or paused / errored out
     """
     last_url = ""
     monitor_deadline = time.time() + CONST_TICKETPLUS_QUEUE_MONITOR_MAX
 
     while time.time() < monitor_deadline:
         if await check_and_handle_pause(config_dict):
-            return
+            return "timeout"
 
         try:
             current_url = tab.url
 
             if '/confirm/' in current_url.lower() or '/confirmseat/' in current_url.lower():
                 debug.log("Detected entry to confirmation page, exiting queue monitoring")
-                return
+                return "confirmed"
 
             if current_url != last_url:
                 debug.log(f"Page status update - URL: {current_url}")
@@ -1509,24 +1550,28 @@ async def _ticketplus_monitor_queue(tab, config_dict, debug):
 
             if await nodriver_ticketplus_accept_order_fail(tab, debug) is True:
                 debug.log("[QUEUE END] Order failure popup dismissed, exiting queue monitoring")
-                return
+                return "order_fail"
 
             if not await nodriver_ticketplus_check_queue_status(tab, config_dict):
                 debug.log("[QUEUE END] Queue ended, continuing page processing")
-                return
+                return "queue_end"
 
             recheck_deadline = time.time() + random.uniform(5.0, 10.0)
             while time.time() < recheck_deadline:
                 if await sleep_with_pause_check(tab, CONST_TICKETPLUS_QUEUE_URL_POLL_INTERVAL, config_dict):
-                    return
+                    return "timeout"
                 if tab.url != current_url:
                     break
+                if await nodriver_ticketplus_accept_order_fail(tab, debug) is True:
+                    debug.log("[QUEUE END] Order failure popup dismissed mid-wait, exiting queue monitoring")
+                    return "order_fail"
 
         except Exception as exc:
             debug.log(f"Queue monitoring error: {exc}")
-            return
+            return "timeout"
 
     debug.log("[QUEUE END] Queue monitoring hit its time limit, returning to main loop")
+    return "timeout"
 
 
 async def nodriver_ticketplus_order(tab, config_dict, ocr, Captcha_Browser):
@@ -1632,7 +1677,19 @@ async def nodriver_ticketplus_order(tab, config_dict, ocr, Captcha_Browser):
 
             if outcome == "queue":
                 debug.log("Entered queue monitoring (recheck every 5-10 seconds, display only on status change)")
-                await _ticketplus_monitor_queue(tab, config_dict, debug)
+                queue_outcome = await _ticketplus_monitor_queue(tab, config_dict, debug)
+
+                # Mirror the direct order_fail path above: the popup is gone but the
+                # ticket counts on screen are stale, so refresh before the next
+                # attempt instead of submitting against them.
+                if queue_outcome == "order_fail":
+                    debug.log("[ORDER FAIL] Popup dismissed during queue monitoring, refreshing ticket availability")
+                    _state["order_page_visited"] = False
+                    try:
+                        await tab.reload()
+                    except Exception as reload_exc:
+                        debug.log(f"[ORDER FAIL] Reload failed: {reload_exc}")
+                    return
 
         debug.log(f"Form submission: {'Success' if is_form_submitted else 'Failed'}")
     else:


### PR DESCRIPTION
## 變更摘要

這是 #389 / PR #390（2026.08.17）的後續修補。該版已加入送單結果輪詢與 queue monitor，但可見的 `.v-dialog__content` 使用 `position: fixed`，其 `offsetParent` 即使顯示中仍為 `null`；現有可見性判斷因此會略過真正顯示中的失敗彈窗，造成「我知道了」仍可能不會自動點擊（#400）。

- 改用 `getBoundingClientRect()` 與 `getComputedStyle()` 判斷 dialog 是否可見
- 掃描所有可見的 Vuetify dialogs，不再只檢查第一個可能未啟用的 `.v-dialog`
- queue monitor 的 5–10 秒隨機等待期間，每 0.5 秒檢查一次失敗彈窗
- 偵測到失敗彈窗後回傳明確結果、關閉彈窗並重新整理票券可售數量

## 變更類型

- [ ] ✨ 新功能 (feat)
- [x] 🐛 Bug 修復 (fix)
- [ ] ♻️ 重構 (refactor)
- [ ] 📝 文件更新 (docs)
- [ ] 🔧 維護 (chore)

## 影響平台

**台灣**
- [ ] TixCraft / TicketMaster / Teamear / Indievox
- [ ] KKTIX
- [ ] iBon / 年代售票
- [x] TicketPlus
- [ ] FamiTicket
- [ ] 寬宏售票（KHAM）
- [ ] FANSI GO
- [ ] FunOne

**海外**
- [ ] Cityline 買飛
- [ ] HKTicketing 快達票

**通用**
- [ ] 跨平台共用功能（nodriver_common / util / settings）

## 驗證方式

- [x] Python AST / syntax check
- [x] 兩段 embedded JavaScript 通過 `node --check`
- [x] 使用 Chrome + Vuetify 2.6 fixture 驗證：失敗彈窗會否決 queue 判定、「我知道了」只點擊一次，關閉後不會重複點擊
- [x] `git diff --check`

## 檢查清單

- [x] 已測試功能正常
- [x] 無敏感資訊（密碼、Cookie、API key）
- [x] `.py` 檔案中沒有使用 emoji

## 範圍說明

本 PR 不會取代作者對 #389 的修正，而是在 PR #390 的基礎上補正 dialog 可見性判斷與 queue wait 期間的處理。既有的整頁 queue keyword 判定維持不變，也不會自動關閉非失敗類公告彈窗。

## 相關 Issue

Closes #400

Follow-up to #389 and PR #390