### PR TITLE
fix(kktix): 修復 KKTIX 自動登入 Turnstile 驗證與中繼頁卡死問題，優化登入流程

### DIFF
--- a/src/nodriver_common.py
+++ b/src/nodriver_common.py
@@ -632,6 +632,31 @@ async def detect_cloudflare_challenge(tab, show_debug=False):
     """
     debug = util.create_debug_logger(enabled=show_debug)
     try:
+        # Pre-check: If Turnstile is embedded on page and already solved (response token present),
+        # verify whether there are still active full-page blocking indicators.
+        # If no blocking indicators, the challenge has already been solved.
+        try:
+            turnstile_solved = await tab.evaluate(
+                '!!(document.querySelector(\'input[name="cf-turnstile-response"]\') && '
+                'document.querySelector(\'input[name="cf-turnstile-response"]\').value && '
+                'document.querySelector(\'input[name="cf-turnstile-response"]\').value.length > 0)'
+            )
+            if turnstile_solved:
+                html_content = await tab.get_content()
+                html_lower = (html_content or "").lower()
+                blocking_indicators = [
+                    "cf-browser-verification",
+                    "cf-challenge-running",
+                    "cf-spinner-allow-5-secs",
+                    "checking your browser",
+                    "please wait while we verify",
+                ]
+                if not any(indicator in html_lower for indicator in blocking_indicators):
+                    debug.log("[CF DETECT] Turnstile response token present and no blocking indicators; challenge resolved")
+                    return False
+        except Exception:
+            pass
+
         # Layer 1: CDP Target detection (most reliable - finds iframes invisible to JS)
         try:
             targets = await tab.send(cdp.target.get_targets())

--- a/src/nodriver_common.py
+++ b/src/nodriver_common.py
@@ -913,6 +913,9 @@ async def handle_cloudflare_challenge(tab, config_dict, max_retry=None):
                             "cf-challenge-running",
                             "cf-spinner-allow-5-secs",
                             "checking your browser",
+                            "正在執行安全驗證",
+                            "__cf_chl_",
+                            "請稍候...",
                         ]
                         still_active = any(ind in html_lower for ind in active_indicators)
                 except Exception as exc:

--- a/src/nodriver_common.py
+++ b/src/nodriver_common.py
@@ -650,6 +650,10 @@ async def detect_cloudflare_challenge(tab, show_debug=False):
                     "cf-spinner-allow-5-secs",
                     "checking your browser",
                     "please wait while we verify",
+                    "正在執行安全驗證",
+                    "__cf_chl_",
+                    "just a moment...",
+                    "請稍候...",
                 ]
                 if not any(indicator in html_lower for indicator in blocking_indicators):
                     debug.log("[CF DETECT] Turnstile response token present and no blocking indicators; challenge resolved")
@@ -695,6 +699,10 @@ async def detect_cloudflare_challenge(tab, show_debug=False):
             "checking your browser",
             "please wait while we verify",
             "verify you are human",
+            "正在執行安全驗證",
+            "__cf_chl_",
+            "just a moment...",
+            "請稍候...",
         ]
 
         detected = any(indicator in html_lower for indicator in cloudflare_indicators)
@@ -839,6 +847,7 @@ async def handle_cloudflare_challenge(tab, config_dict, max_retry=None):
                                     var cjk = [
                                         "\u8acb\u8b93\u6211\u5011\u77e5\u9053\u60a8\u662f\u4eba\u985e",
                                         "\u9a57\u8b49\u60a8\u662f\u4eba\u985e",
+                                        "\u6b63\u5728\u57f7\u884c\u5b89\u5168\u9a57\u8b42",
                                         "\u4eba\u9593\u3067\u3042\u308b\u3053\u3068\u3092\u78ba\u8a8d"
                                     ];
                                     for (var k = 0; k < cjk.length; k++) {

--- a/src/nodriver_common.py
+++ b/src/nodriver_common.py
@@ -11,6 +11,7 @@ Dependency: util.py, settings.py, chrome_downloader.py (no platform imports)
 import asyncio
 import json
 import os
+import random
 import traceback
 
 from zendriver import cdp
@@ -651,7 +652,6 @@ async def detect_cloudflare_challenge(tab, show_debug=False):
                     "checking your browser",
                     "please wait while we verify",
                     "正在執行安全驗證",
-                    "__cf_chl_",
                     "just a moment...",
                     "請稍候...",
                 ]
@@ -700,7 +700,6 @@ async def detect_cloudflare_challenge(tab, show_debug=False):
             "please wait while we verify",
             "verify you are human",
             "正在執行安全驗證",
-            "__cf_chl_",
             "just a moment...",
             "請稍候...",
         ]
@@ -747,17 +746,24 @@ def _find_cf_iframe_in_dom(node, depth=0):
     return (None, None)
 
 
-async def _cdp_click(tab, x, y):
-    """Dispatch CDP mousePressed + mouseReleased at (x, y)."""
+async def cdp_click(tab, x, y):
+    """Dispatch CDP mouseMoved + mousePressed + mouseReleased at (x, y) with natural timing."""
+    await tab.send(cdp.input_.dispatch_mouse_event(
+        type_="mouseMoved", x=x, y=y
+    ))
+    await tab.sleep(random.uniform(0.04, 0.08))
     await tab.send(cdp.input_.dispatch_mouse_event(
         type_="mousePressed", x=x, y=y,
-        button=cdp.input_.MouseButton("left"), click_count=1
+        button=cdp.input_.MouseButton("left"), buttons=1, click_count=1
     ))
-    await tab.sleep(0.05)
+    await tab.sleep(random.uniform(0.06, 0.12))
     await tab.send(cdp.input_.dispatch_mouse_event(
         type_="mouseReleased", x=x, y=y,
-        button=cdp.input_.MouseButton("left"), click_count=1
+        button=cdp.input_.MouseButton("left"), buttons=0, click_count=1
     ))
+
+
+_cdp_click = cdp_click
 
 
 async def handle_cloudflare_challenge(tab, config_dict, max_retry=None):
@@ -899,26 +905,44 @@ async def handle_cloudflare_challenge(tab, config_dict, max_retry=None):
             # Polling ensures we catch the exact moment the challenge resolves without
             # prematurely declaring failure or reloading the page.
             if clicked:
+                # Check if this is an embedded Turnstile widget or a full-page challenge
+                has_embedded_turnstile = False
+                try:
+                    has_embedded_turnstile = await tab.evaluate(
+                        '!!document.querySelector(\'input[name="cf-turnstile-response"]\')'
+                    )
+                except Exception:
+                    pass
+
                 still_active = True
                 for poll_step in range(16):  # Poll up to 8s (0.5s intervals)
                     await tab.sleep(0.5)
                     try:
-                        html_content = await tab.get_content()
-                        if html_content:
-                            html_lower = html_content.lower()
-                            active_indicators = [
-                                "cf-browser-verification",
-                                "cf-challenge-running",
-                                "cf-spinner-allow-5-secs",
-                                "checking your browser",
-                                "正在執行安全驗證",
-                                "__cf_chl_",
-                                "請稍候...",
-                            ]
-                            still_active = any(ind in html_lower for ind in active_indicators)
-                            if not still_active:
-                                debug.log(f"[CLOUDFLARE] Challenge bypassed successfully (resolved in {poll_step * 0.5 + 0.5:.1f}s)")
+                        if has_embedded_turnstile:
+                            token_val = await tab.evaluate(
+                                'document.querySelector(\'input[name="cf-turnstile-response"]\') ? '
+                                'document.querySelector(\'input[name="cf-turnstile-response"]\').value : ""'
+                            )
+                            token_val = util.parse_nodriver_result(token_val)
+                            if token_val and len(token_val) > 20:
+                                debug.log(f"[CLOUDFLARE] Embedded Turnstile token received (len={len(token_val)}) in {poll_step * 0.5 + 0.5:.1f}s")
                                 return True
+                        else:
+                            html_content = await tab.get_content()
+                            if html_content:
+                                html_lower = html_content.lower()
+                                active_indicators = [
+                                    "cf-browser-verification",
+                                    "cf-challenge-running",
+                                    "cf-spinner-allow-5-secs",
+                                    "checking your browser",
+                                    "正在執行安全驗證",
+                                    "請稍候...",
+                                ]
+                                still_active = any(ind in html_lower for ind in active_indicators)
+                                if not still_active:
+                                    debug.log(f"[CLOUDFLARE] Challenge bypassed successfully (resolved in {poll_step * 0.5 + 0.5:.1f}s)")
+                                    return True
                     except Exception as exc:
                         debug.log(f"[CLOUDFLARE] Post-click verification check: {exc}")
                         still_active = True
@@ -1028,45 +1052,11 @@ async def with_pause_check(task_func, config_dict, *args, **kwargs):
 def get_nodriver_browser_args():
     """
     Get nodriver browser args.
-    Based on verified args that pass Cloudflare checks.
+    Uses zendriver default args verified to pass Cloudflare checks.
     """
-    # Browser args verified to pass Cloudflare checks
-    browser_args = [
-        "--disable-animations",
-        "--disable-app-info-dialog-mac",
-        "--disable-background-networking",
-        "--disable-backgrounding-occluded-windows",
-        "--disable-breakpad",
-        "--disable-component-update",
-        "--disable-default-apps",
-        "--disable-dev-shm-usage",
-        "--disable-device-discovery-notifications",
-        "--disable-dinosaur-easter-egg",
-        "--disable-domain-reliability",
-        "--disable-features=IsolateOrigins,site-per-process,TranslateUI",
-        "--disable-infobars",
-        "--disable-logging",
-        "--disable-login-animations",
-        "--disable-login-screen-apps",
-        "--disable-notifications",
-        "--disable-password-generation",
-        "--disable-popup-blocking",
-        "--disable-renderer-backgrounding",
-        "--disable-session-crashed-bubble",
-        "--disable-smooth-scrolling",
-        "--disable-suggestions-ui",
-        "--disable-sync",
-        "--disable-translate",
-        "--hide-crash-restore-bubble",
-        "--homepage=about:blank",
-        "--no-default-browser-check",
-        "--no-first-run",
-        "--no-pings",
-        "--no-service-autorun",
-        "--password-store=basic",
-        # Note: --remote-debugging-host is managed by Config(host=...) when MCP debug is enabled
-        "--lang=zh-TW",
-    ]
+    browser_args = list(Config().browser_args)
+    if "--lang=zh-TW" not in browser_args:
+        browser_args.append("--lang=zh-TW")
 
     # Expert mode: cautiously add high-risk args
     if CLOUDFLARE_ENABLE_EXPERT_MODE:

--- a/src/nodriver_common.py
+++ b/src/nodriver_common.py
@@ -894,53 +894,46 @@ async def handle_cloudflare_challenge(tab, config_dict, max_retry=None):
                 except Exception:
                     pass
 
-            # Wait for challenge to resolve
-            wait_time = CLOUDFLARE_WAIT_TIME + (retry_count * 2)
-            await tab.sleep(wait_time)
-
             # Verify: check if CF challenge is resolved
-            # Note: CDP target persists even after solved Turnstile, so use HTML-only check
-            # when a click was dispatched. HTML active indicators only appear in full-page
-            # interstitials, not in embedded (solved) Turnstile widgets.
+            # Note: Cloudflare verification typically takes 2-6 seconds after click.
+            # Polling ensures we catch the exact moment the challenge resolves without
+            # prematurely declaring failure or reloading the page.
             if clicked:
-                still_active = False
-                try:
-                    html_content = await tab.get_content()
-                    if html_content:
-                        html_lower = html_content.lower()
-                        active_indicators = [
-                            "cf-browser-verification",
-                            "cf-challenge-running",
-                            "cf-spinner-allow-5-secs",
-                            "checking your browser",
-                            "正在執行安全驗證",
-                            "__cf_chl_",
-                            "請稍候...",
-                        ]
-                        still_active = any(ind in html_lower for ind in active_indicators)
-                except Exception as exc:
-                    debug.log(f"[CLOUDFLARE] Post-click verification failed: {exc}")
-                    still_active = True
+                still_active = True
+                for poll_step in range(16):  # Poll up to 8s (0.5s intervals)
+                    await tab.sleep(0.5)
+                    try:
+                        html_content = await tab.get_content()
+                        if html_content:
+                            html_lower = html_content.lower()
+                            active_indicators = [
+                                "cf-browser-verification",
+                                "cf-challenge-running",
+                                "cf-spinner-allow-5-secs",
+                                "checking your browser",
+                                "正在執行安全驗證",
+                                "__cf_chl_",
+                                "請稍候...",
+                            ]
+                            still_active = any(ind in html_lower for ind in active_indicators)
+                            if not still_active:
+                                debug.log(f"[CLOUDFLARE] Challenge bypassed successfully (resolved in {poll_step * 0.5 + 0.5:.1f}s)")
+                                return True
+                    except Exception as exc:
+                        debug.log(f"[CLOUDFLARE] Post-click verification check: {exc}")
+                        still_active = True
                 if not still_active:
                     debug.log("[CLOUDFLARE] Challenge bypassed successfully")
                     return True
             else:
-                # No click dispatched; use full detection
+                # No click dispatched; wait and use full detection
+                wait_time = CLOUDFLARE_WAIT_TIME + (retry_count * 2)
+                await tab.sleep(wait_time)
                 if not await detect_cloudflare_challenge(tab, cf_debug):
                     debug.log("[CLOUDFLARE] Challenge resolved (no click needed)")
                     return True
 
             debug.log(f"[CLOUDFLARE] Attempt {retry_count + 1} unsuccessful")
-
-            if retry_count == max_retry - 1:
-                try:
-                    debug.log("[CLOUDFLARE] Last attempt: Refreshing page")
-                    await tab.reload()
-                    await tab.sleep(5)
-                    if not await detect_cloudflare_challenge(tab, cf_debug):
-                        return True
-                except Exception:
-                    pass
 
         except Exception as exc:
             debug.log(f"[CLOUDFLARE] Error during processing: {exc}")

--- a/src/nodriver_tixcraft.py
+++ b/src/nodriver_tixcraft.py
@@ -85,7 +85,7 @@ async def nodriver_goto_homepage(driver, config_dict):
         # Shared with nodriver_kktix_signin and the guest redirect so all three
         # agree on what counts as "configured" (issue #374).
         if is_kktix_account_configured(config_dict):
-            if not 'https://kktix.com/users/sign_in?' in homepage:
+            if '/users/sign_in' not in homepage:
                 homepage = CONST_KKTIX_SIGN_IN_URL % (homepage)
 
     if 'famiticket.com' in homepage:
@@ -876,9 +876,9 @@ async def main(args):
 
         # Cloudflare challenge detection (only on URL change to avoid performance hit)
         # After 3 consecutive failures on same URL, stop retrying to avoid infinite loop
-        # Skip Cityline Login page: Turnstile there is part of the login form, not a block
-        # (covers both cityline.com and the venue cityline.com.hk login pages)
-        if is_cityline_login_page(url):
+        # Skip Cityline & KKTIX Login pages: Turnstile there is part of the login form, not a block
+        # (covers both cityline.com and the venue cityline.com.hk login pages, as well as KKTIX sign in)
+        if is_cityline_login_page(url) or is_kktix_login_page(url):
             cloudflare_checked = True
         if not cloudflare_checked and cloudflare_fail_count < 3:
             is_cloudflare = await detect_cloudflare_challenge(tab, show_debug=config_dict.get("advanced", {}).get("verbose", False))

--- a/src/nodriver_tixcraft.py
+++ b/src/nodriver_tixcraft.py
@@ -75,13 +75,6 @@ async def nodriver_goto_homepage(driver, config_dict):
     tab = None
     homepage = config_dict["homepage"]
     if 'kktix.c' in homepage:
-        # for like human.
-        try:
-            tab = await driver.get(homepage)
-            await asyncio.sleep(random.uniform(1.0, 2.5))
-        except Exception as e:
-            print(f"[ERROR] Failed to navigate to kktix homepage: {e}")
-
         # Shared with nodriver_kktix_signin and the guest redirect so all three
         # agree on what counts as "configured" (issue #374).
         if is_kktix_account_configured(config_dict):

--- a/src/nodriver_tixcraft.py
+++ b/src/nodriver_tixcraft.py
@@ -47,7 +47,12 @@ from platforms.cityline import *
 from platforms.famiticket import *
 from platforms.ticketplus import *
 from platforms.funone import *
-from platforms.kktix import *
+from platforms.kktix import (
+    is_kktix_account_configured,
+    is_kktix_login_page,
+    nodriver_kktix_main,
+    nodriver_kktix_paused_main,
+)
 from platforms.tixcraft import *
 from platforms.ibon import *
 from platforms.kham import *

--- a/src/platforms/kktix.py
+++ b/src/platforms/kktix.py
@@ -20,6 +20,7 @@ from zendriver import cdp
 import util
 from nodriver_common import (
     check_and_handle_pause,
+    handle_cloudflare_challenge,
     nodriver_check_checkbox,
     play_sound_while_ordering,
     send_discord_notification,
@@ -31,6 +32,7 @@ from nodriver_common import (
 )
 
 __all__ = [
+    "is_kktix_login_page",
     "nodriver_kktix_signin",
     "nodriver_kktix_paused_main",
     "nodriver_kktix_travel_price_list",
@@ -57,6 +59,12 @@ __all__ = [
     "nodriver_kktix_handle_qualification_and_next",
     "CONST_KKTIX_FORM_STATE_JS",
 ]
+
+def is_kktix_login_page(url):
+    """True for KKTIX sign_in page."""
+    if not url:
+        return False
+    return ('kktix.com' in url or 'kktix.cc' in url) and '/users/sign_in' in url
 
 # Module-level state (replaces global kktix_dict)
 _state = {}
@@ -162,15 +170,51 @@ async def nodriver_kktix_signin(tab, url, config_dict):
                 debug.log("[KKTIX SIGNIN] #user_login not found; page may be a queue room, "
                           "a Cloudflare challenge, or already signed in")
                 return False
-            await account.send_keys(kktix_account)
+
+            account_val = await tab.evaluate('document.querySelector("#user_login") ? document.querySelector("#user_login").value : null')
+            if account_val != kktix_account:
+                await tab.evaluate('if (document.querySelector("#user_login")) { document.querySelector("#user_login").value = ""; }')
+                await account.send_keys(kktix_account)
             await asyncio.sleep(random.uniform(0.1, 0.2))
 
             password = await tab.query_selector("#user_password")
             if password is None:
                 debug.log("[KKTIX SIGNIN] #user_password not found; login form is incomplete")
                 return False
-            await password.send_keys(kktix_password)
+
+            password_val = await tab.evaluate('document.querySelector("#user_password") ? document.querySelector("#user_password").value : null')
+            if password_val != kktix_password:
+                await tab.evaluate('if (document.querySelector("#user_password")) { document.querySelector("#user_password").value = ""; }')
+                await password.send_keys(kktix_password)
             await asyncio.sleep(random.uniform(0.1, 0.2))
+
+            # If Turnstile challenge widget is present on login form, ensure it is solved before submitting
+            has_turnstile = await tab.evaluate('''
+                (function() {
+                    return !!(
+                        document.querySelector('.cf-turnstile') ||
+                        document.querySelector('iframe[src*="challenges.cloudflare.com"]') ||
+                        document.querySelector('input[name="cf-turnstile-response"]')
+                    );
+                })()
+            ''')
+            if has_turnstile:
+                debug.log("[KKTIX SIGNIN] Turnstile widget detected on login form, checking status...")
+                turnstile_solved = False
+                for wait_step in range(10):
+                    turnstile_solved = await tab.evaluate('''
+                        (function() {
+                            const input = document.querySelector('input[name="cf-turnstile-response"]');
+                            return !!(input && input.value && input.value.length > 0);
+                        })()
+                    ''')
+                    if turnstile_solved:
+                        debug.log("[KKTIX SIGNIN] Turnstile challenge solved")
+                        break
+                    if wait_step == 1 or wait_step == 4:
+                        debug.log("[KKTIX SIGNIN] Turnstile not solved, attempting CDP solve...")
+                        await handle_cloudflare_challenge(tab, config_dict, max_retry=2)
+                    await asyncio.sleep(0.5)
 
             # The submit button used to be matched by its Chinese value only,
             # which fails silently on any other locale.
@@ -324,11 +368,8 @@ async def nodriver_kktix_redirect_to_signin_if_guest(tab, url, config_dict):
 async def nodriver_kktix_paused_main(tab, url, config_dict):
     debug = util.create_debug_logger(config_dict)
 
-    is_url_contain_sign_in = False
-    if '/users/sign_in?' in url:
+    if is_kktix_login_page(url):
         redirect_needed = await nodriver_kktix_signin(tab, url, config_dict)
-        is_url_contain_sign_in = True
-
         return redirect_needed
 
     return False
@@ -2116,7 +2157,7 @@ def check_kktix_got_ticket(url, config_dict):
     if '/events/' in url and '/registrations/' in url and "-" in url:
         if not '/registrations/new' in url:
             if not '#/booking' in url:
-                if not 'https://kktix.com/users/sign_in?' in url:
+                if not is_kktix_login_page(url):
                     is_kktix_got_ticket = True
                     debug.log(f"[KKTIX] Success page detected: {url}")
 
@@ -2215,14 +2256,15 @@ async def nodriver_kktix_main(tab, url, config_dict):
             debug.log(f"[KKTIX ALERT] Failed to register alert handler: {handler_exc}")
 
     is_url_contain_sign_in = False
-    if '/users/sign_in?' in url:
+    if is_kktix_login_page(url):
+        is_url_contain_sign_in = True
         # nodriver_kktix_signin already handles smart polling and redirect
         await nodriver_kktix_signin(tab, url, config_dict)
 
         # Update URL after signin completes
         try:
             url = await tab.evaluate('window.location.href')
-            is_url_contain_sign_in = False
+            is_url_contain_sign_in = is_kktix_login_page(url)
         except Exception as exc:
             debug.log(f"取得跳轉後 URL 失敗: {exc}")
 

--- a/src/platforms/kktix.py
+++ b/src/platforms/kktix.py
@@ -20,6 +20,7 @@ from zendriver import cdp
 import util
 from nodriver_common import (
     check_and_handle_pause,
+    detect_cloudflare_challenge,
     handle_cloudflare_challenge,
     nodriver_check_checkbox,
     play_sound_while_ordering,
@@ -167,8 +168,12 @@ async def nodriver_kktix_signin(tab, url, config_dict):
             # in the log. Report it and stop instead of submitting a dead form.
             account = await tab.query_selector("#user_login")
             if account is None:
-                debug.log("[KKTIX SIGNIN] #user_login not found; page may be a queue room, "
-                          "a Cloudflare challenge, or already signed in")
+                # Check if page is currently intercepted by a Cloudflare challenge
+                if await detect_cloudflare_challenge(tab, show_debug=True):
+                    debug.log("[KKTIX SIGNIN] Cloudflare challenge page detected, attempting to solve...")
+                    await handle_cloudflare_challenge(tab, config_dict)
+                    return False
+                debug.log("[KKTIX SIGNIN] #user_login not found; page may be a queue room or already signed in")
                 return False
 
             account_val = await tab.evaluate('document.querySelector("#user_login") ? document.querySelector("#user_login").value : null')
@@ -282,6 +287,22 @@ async def nodriver_kktix_signin(tab, url, config_dict):
                         login_completed = True
                         debug.log(f"[KKTIX SIGNIN] Login completed after {attempt * check_interval:.1f}s, redirected to: {current_url}")
                         break
+
+                    # Check if Cloudflare challenge took over the page after submit
+                    if attempt >= 2:
+                        if await detect_cloudflare_challenge(tab, show_debug=False):
+                            debug.log("[KKTIX SIGNIN] Cloudflare challenge detected after submit, solving...")
+                            await handle_cloudflare_challenge(tab, config_dict)
+                            # Poll for navigation after CF solve
+                            for _ in range(8):
+                                await asyncio.sleep(0.5)
+                                cur_url = await tab.evaluate('window.location.href')
+                                if '/users/sign_in' not in cur_url:
+                                    login_completed = True
+                                    debug.log(f"[KKTIX SIGNIN] Redirected after CF solve: {cur_url}")
+                                    break
+                            if login_completed:
+                                break
                 except Exception as exc:
                     # Report the first failure with its attempt index, then only
                     # the summary below; printing every attempt floods the log.

--- a/src/platforms/kktix.py
+++ b/src/platforms/kktix.py
@@ -19,9 +19,11 @@ from zendriver import cdp
 
 import util
 from nodriver_common import (
+    cdp_click,
     check_and_handle_pause,
     detect_cloudflare_challenge,
     handle_cloudflare_challenge,
+    _find_cf_iframe_in_dom,
     nodriver_check_checkbox,
     play_sound_while_ordering,
     send_discord_notification,
@@ -200,6 +202,15 @@ async def nodriver_kktix_signin(tab, url, config_dict):
             if account_val != kktix_account:
                 await tab.evaluate('if (document.querySelector("#user_login")) { document.querySelector("#user_login").value = ""; }')
                 await account.send_keys(kktix_account)
+                await tab.evaluate('''
+                    (function() {
+                        const el = document.querySelector("#user_login");
+                        if (el) {
+                            el.dispatchEvent(new Event('input', { bubbles: true }));
+                            el.dispatchEvent(new Event('change', { bubbles: true }));
+                        }
+                    })()
+                ''')
             await asyncio.sleep(random.uniform(0.1, 0.2))
 
             password = await tab.query_selector("#user_password")
@@ -211,6 +222,15 @@ async def nodriver_kktix_signin(tab, url, config_dict):
             if password_val != kktix_password:
                 await tab.evaluate('if (document.querySelector("#user_password")) { document.querySelector("#user_password").value = ""; }')
                 await password.send_keys(kktix_password)
+                await tab.evaluate('''
+                    (function() {
+                        const el = document.querySelector("#user_password");
+                        if (el) {
+                            el.dispatchEvent(new Event('input', { bubbles: true }));
+                            el.dispatchEvent(new Event('change', { bubbles: true }));
+                        }
+                    })()
+                ''')
             await asyncio.sleep(random.uniform(0.1, 0.2))
 
             # If Turnstile challenge widget is present on login form, ensure it is solved before submitting
@@ -225,88 +245,71 @@ async def nodriver_kktix_signin(tab, url, config_dict):
             ''')
             if has_turnstile:
                 debug.log("[KKTIX SIGNIN] Turnstile widget detected on login form, checking status...")
-                # Clear stale submitted response token if any to avoid re-submitting an expired token
-                await tab.evaluate('''
+                # First check if token is already present
+                token_val = await tab.evaluate('''
                     (function() {
                         const input = document.querySelector('input[name="cf-turnstile-response"]');
-                        if (input && input.dataset.submitted === "true") {
-                            input.value = "";
-                            input.removeAttribute('data-submitted');
-                        }
+                        return (input && input.value) ? input.value : "";
                     })()
                 ''')
-                turnstile_solved = False
-                for wait_step in range(12):
-                    turnstile_solved = await tab.evaluate('''
-                        (function() {
-                            const input = document.querySelector('input[name="cf-turnstile-response"]');
-                            return !!(input && input.value && input.value.length > 0);
-                        })()
-                    ''')
-                    if turnstile_solved:
-                        debug.log("[KKTIX SIGNIN] Turnstile challenge solved")
-                        break
-                    if wait_step == 1 or wait_step == 5:
-                        debug.log("[KKTIX SIGNIN] Turnstile not solved, attempting CDP solve...")
-                        await handle_cloudflare_challenge(tab, config_dict, max_retry=1)
-                    await asyncio.sleep(0.5)
+                token_val = util.parse_nodriver_result(token_val)
 
-                # Mark token as submitted so it won't be reused on next loop
-                await tab.evaluate('''
-                    (function() {
-                        const input = document.querySelector('input[name="cf-turnstile-response"]');
-                        if (input) input.dataset.submitted = "true";
-                    })()
-                ''')
+                if not (token_val and len(token_val) > 20):
+                    # Find Turnstile iframe and click checkbox via CDP
+                    try:
+                        doc = await tab.send(cdp.dom.get_document(depth=-1, pierce=True))
+                        node_id, src = _find_cf_iframe_in_dom(doc)
+                        if node_id:
+                            box = await tab.send(cdp.dom.get_box_model(node_id=node_id))
+                            if box and box.content and len(box.content) >= 6:
+                                cx = box.content[0] + 30
+                                cy = box.content[1] + (box.content[5] - box.content[1]) / 2
+                                debug.log(f"[KKTIX SIGNIN] Clicking Turnstile at ({cx:.1f}, {cy:.1f})")
+                                await cdp_click(tab, cx, cy)
+                    except Exception as cf_e:
+                        debug.log(f"[KKTIX SIGNIN] Turnstile CDP click error: {cf_e}")
 
-            # The submit button used to be matched by its Chinese value only,
-            # which fails silently on any other locale.
-            submit_result = await tab.evaluate('''
+                    # Wait for token
+                    for s in range(20):
+                        await asyncio.sleep(0.5)
+                        token_val = await tab.evaluate('document.querySelector("input[name=\\"cf-turnstile-response\\"]") ? document.querySelector("input[name=\\"cf-turnstile-response\\"]").value : ""')
+                        token_val = util.parse_nodriver_result(token_val)
+                        if token_val and len(token_val) > 20:
+                            debug.log(f"[KKTIX SIGNIN] Token acquired in {s*0.5+0.5:.1f}s! len={len(token_val)}")
+                            break
+
+                if token_val and len(token_val) > 20:
+                    _state["last_kktix_turnstile_token"] = token_val
+                    debug.log(f"[KKTIX SIGNIN] Fresh Turnstile token confirmed (len={len(token_val)})")
+                else:
+                    debug.log("[KKTIX SIGNIN] Turnstile token not obtained, aborting submit for this attempt")
+                    return False
+
+            # Click submit button via CDP to produce trusted native click (event.isTrusted = true)
+            submit_btn_info = await tab.evaluate('''
                 (function() {
-                    const selectors = [
-                        'form#new_user input[type="submit"]',
-                        'form[action*="sign_in"] input[type="submit"]',
-                        'input[type="submit"][value="登入"]',
-                        'button[type="submit"]'
-                    ];
-                    let candidateCount = 0;
-                    for (const sel of selectors) {
-                        const btn = document.querySelector(sel);
-                        if (btn) {
-                            candidateCount += 1;
-                            if (!btn.disabled) {
-                                btn.click();
-                                return { clicked: true, selector: sel, candidateCount: candidateCount };
-                            }
-                        }
+                    const btn = document.querySelector('form#new_user input[type="submit"]') ||
+                                document.querySelector('form[action*="sign_in"] input[type="submit"]') ||
+                                document.querySelector('input[type="submit"][value="登入"]') ||
+                                document.querySelector('button[type="submit"]');
+                    if (btn && !btn.disabled) {
+                        const r = btn.getBoundingClientRect();
+                        return { found: true, x: r.x + r.width / 2, y: r.y + r.height / 2 };
                     }
-                    return { clicked: false, selector: '', candidateCount: candidateCount };
+                    return { found: false };
                 })()
             ''')
-            submit_result = util.parse_nodriver_result(submit_result)
-            if isinstance(submit_result, dict) and submit_result.get('clicked'):
-                debug.log(f"[KKTIX SIGNIN] Submit clicked via {submit_result.get('selector')}")
+            submit_btn_info = util.parse_nodriver_result(submit_btn_info)
+            if isinstance(submit_btn_info, dict) and submit_btn_info.get('found'):
+                debug.log(f"[KKTIX SIGNIN] Submit clicked via CDP at ({submit_btn_info['x']:.0f}, {submit_btn_info['y']:.0f})")
+                await cdp_click(tab, submit_btn_info['x'], submit_btn_info['y'])
             else:
-                candidate_count = 0
-                if isinstance(submit_result, dict):
-                    candidate_count = submit_result.get('candidateCount', 0)
-                debug.log(f"[KKTIX SIGNIN] No clickable submit button found "
-                          f"(candidates={candidate_count}); locale may differ or form not rendered")
+                debug.log("[KKTIX SIGNIN] No clickable submit button found; locale may differ or form not rendered")
                 return False
 
             # Smart polling: wait for login completion (URL change from sign_in page)
-            #
-            # Do NOT add an early return when Cloudflare takes over the page.
-            # It was tried and measurably made things worse: the main loop's
-            # Cloudflare check only re-arms on a URL change, and returning during
-            # the __cf_chl_rt_tk redirect means it runs before the challenge
-            # target exists, finds nothing, and never looks again - the bot then
-            # idles forever. Sitting out the full 10s wastes time but gives the
-            # challenge time to render, which is what lets the main loop solve it.
-            # Fixing this properly needs event-driven detection
-            # (cdp.target.TargetCreated), not an earlier poll.
-            max_wait = 10
-            check_interval = 0.3
+            max_wait = 20
+            check_interval = 0.5
             max_attempts = int(max_wait / check_interval)
             login_completed = False
             url_error_count = 0
@@ -319,54 +322,24 @@ async def nodriver_kktix_signin(tab, url, config_dict):
 
                 try:
                     current_url = await tab.evaluate('window.location.href')
+                    current_url = util.parse_nodriver_result(current_url)
+                    title = await tab.evaluate('document.title')
+                    title = util.parse_nodriver_result(title)
+
+                    if attempt % 3 == 0 or attempt == max_attempts - 1:
+                        debug.log(f"[KKTIX SIGNIN POLL] attempt {attempt}: url={current_url}, title='{title}'")
 
                     # Detect if left sign_in page (login completed)
-                    if '/users/sign_in' not in current_url:
+                    if current_url and not is_kktix_login_page(current_url) and '__cf_chl_' not in current_url:
                         login_completed = True
                         debug.log(f"[KKTIX SIGNIN] Login completed after {attempt * check_interval:.1f}s, redirected to: {current_url}")
+                        has_redirected = True
                         break
-
-                    # Check if Cloudflare challenge took over the page after submit
-                    if attempt >= 2:
-                        if await detect_cloudflare_challenge(tab, show_debug=False):
-                            debug.log("[KKTIX SIGNIN] Cloudflare challenge detected after submit, solving...")
-                            await handle_cloudflare_challenge(tab, config_dict, max_retry=1)
-                            # Wait for Cloudflare challenge to verify and navigate away
-                            for _ in range(16):  # up to 8s
-                                await asyncio.sleep(0.5)
-                                cur_state = await tab.evaluate('''
-                                    (function() {
-                                        var text = document.body ? document.body.innerText : '';
-                                        var cf_active = text.includes('正在執行安全驗證') || 
-                                                        text.includes('請稍候') ||
-                                                        window.location.search.includes('__cf_chl_') ||
-                                                        !!window._cf_chl_opt;
-                                        return {
-                                            url: window.location.href,
-                                            cf_active: cf_active
-                                        };
-                                    })()
-                                ''')
-                                cur_state = util.parse_nodriver_result(cur_state)
-                                if isinstance(cur_state, dict):
-                                    cur_url = cur_state.get('url', '')
-                                    cf_active = cur_state.get('cf_active', True)
-                                    if not cf_active:
-                                        if '/users/sign_in' not in cur_url:
-                                            login_completed = True
-                                            debug.log(f"[KKTIX SIGNIN] Redirected after CF solve: {cur_url}")
-                                        else:
-                                            debug.log("[KKTIX SIGNIN] CF clearance passed, returned to sign_in to submit credentials")
-                                        break
-                            break  # Exit attempt loop so nodriver_kktix_signin can cleanly handle the new state
                 except Exception as exc:
-                    # Report the first failure with its attempt index, then only
-                    # the summary below; printing every attempt floods the log.
                     url_error_count += 1
                     last_url_exc = str(exc)
                     if url_error_count == 1:
-                        debug.log(f"[KKTIX SIGNIN] URL check failed "
-                                  f"(attempt {attempt + 1}/{max_attempts}): {exc}")
+                        debug.log(f"[KKTIX SIGNIN] URL check failed (attempt {attempt + 1}/{max_attempts}): {exc}")
 
                 if attempt < max_attempts - 1:
                     await asyncio.sleep(check_interval)
@@ -379,6 +352,7 @@ async def nodriver_kktix_signin(tab, url, config_dict):
             # Check if need to manually redirect to back_to URL
             try:
                 current_url = await tab.evaluate('window.location.href')
+                current_url = util.parse_nodriver_result(current_url)
                 if current_url and ('kktix.com/' in current_url or 'kktix.cc/' in current_url):
                     if '/users/sign_in' in current_url:
                         # Still on sign_in page (login failed or queue intercepted);

--- a/src/platforms/kktix.py
+++ b/src/platforms/kktix.py
@@ -141,13 +141,20 @@ async def nodriver_kktix_signin(tab, url, config_dict):
 
     debug.log("nodriver_kktix_signin:", url)
 
-    # 解析 back_to 參數取得真正的目標頁面
-    target_url = config_dict["homepage"]  # 預設值
+    # 解析 back_to 參數取得真正的目標頁面，並記錄到 _state 以免重導後遺失
+    target_url = _state.get("kktix_target_url", config_dict["homepage"])
     try:
         parsed_url = urllib.parse.urlparse(url)
         params = urllib.parse.parse_qs(parsed_url.query)
         if 'back_to' in params and len(params['back_to']) > 0:
             target_url = params['back_to'][0]
+            _state["kktix_target_url"] = target_url
+        elif 'back_to' in config_dict.get("homepage", ""):
+            parsed_home = urllib.parse.urlparse(config_dict["homepage"])
+            home_params = urllib.parse.parse_qs(parsed_home.query)
+            if 'back_to' in home_params and len(home_params['back_to']) > 0:
+                target_url = home_params['back_to'][0]
+                _state["kktix_target_url"] = target_url
     except Exception as exc:
         debug.log(f"[KKTIX SIGNIN] Failed to parse back_to parameter: {exc}")
 
@@ -171,7 +178,20 @@ async def nodriver_kktix_signin(tab, url, config_dict):
                 # Check if page is currently intercepted by a Cloudflare challenge
                 if await detect_cloudflare_challenge(tab, show_debug=True):
                     debug.log("[KKTIX SIGNIN] Cloudflare challenge page detected, attempting to solve...")
-                    await handle_cloudflare_challenge(tab, config_dict)
+                    await handle_cloudflare_challenge(tab, config_dict, max_retry=1)
+                    for _ in range(16):
+                        await asyncio.sleep(0.5)
+                        cf_active = await tab.evaluate('''
+                            (function() {
+                                var text = document.body ? document.body.innerText : '';
+                                return text.includes('正在執行安全驗證') || 
+                                       text.includes('請稍候') ||
+                                       window.location.search.includes('__cf_chl_') ||
+                                       !!window._cf_chl_opt;
+                            })()
+                        ''')
+                        if not cf_active:
+                            break
                     return False
                 debug.log("[KKTIX SIGNIN] #user_login not found; page may be a queue room or already signed in")
                 return False
@@ -205,8 +225,18 @@ async def nodriver_kktix_signin(tab, url, config_dict):
             ''')
             if has_turnstile:
                 debug.log("[KKTIX SIGNIN] Turnstile widget detected on login form, checking status...")
+                # Clear stale submitted response token if any to avoid re-submitting an expired token
+                await tab.evaluate('''
+                    (function() {
+                        const input = document.querySelector('input[name="cf-turnstile-response"]');
+                        if (input && input.dataset.submitted === "true") {
+                            input.value = "";
+                            input.removeAttribute('data-submitted');
+                        }
+                    })()
+                ''')
                 turnstile_solved = False
-                for wait_step in range(10):
+                for wait_step in range(12):
                     turnstile_solved = await tab.evaluate('''
                         (function() {
                             const input = document.querySelector('input[name="cf-turnstile-response"]');
@@ -216,10 +246,18 @@ async def nodriver_kktix_signin(tab, url, config_dict):
                     if turnstile_solved:
                         debug.log("[KKTIX SIGNIN] Turnstile challenge solved")
                         break
-                    if wait_step == 1 or wait_step == 4:
+                    if wait_step == 1 or wait_step == 5:
                         debug.log("[KKTIX SIGNIN] Turnstile not solved, attempting CDP solve...")
-                        await handle_cloudflare_challenge(tab, config_dict, max_retry=2)
+                        await handle_cloudflare_challenge(tab, config_dict, max_retry=1)
                     await asyncio.sleep(0.5)
+
+                # Mark token as submitted so it won't be reused on next loop
+                await tab.evaluate('''
+                    (function() {
+                        const input = document.querySelector('input[name="cf-turnstile-response"]');
+                        if (input) input.dataset.submitted = "true";
+                    })()
+                ''')
 
             # The submit button used to be matched by its Chinese value only,
             # which fails silently on any other locale.
@@ -292,17 +330,35 @@ async def nodriver_kktix_signin(tab, url, config_dict):
                     if attempt >= 2:
                         if await detect_cloudflare_challenge(tab, show_debug=False):
                             debug.log("[KKTIX SIGNIN] Cloudflare challenge detected after submit, solving...")
-                            await handle_cloudflare_challenge(tab, config_dict)
-                            # Poll for navigation after CF solve
-                            for _ in range(8):
+                            await handle_cloudflare_challenge(tab, config_dict, max_retry=1)
+                            # Wait for Cloudflare challenge to verify and navigate away
+                            for _ in range(16):  # up to 8s
                                 await asyncio.sleep(0.5)
-                                cur_url = await tab.evaluate('window.location.href')
-                                if '/users/sign_in' not in cur_url:
-                                    login_completed = True
-                                    debug.log(f"[KKTIX SIGNIN] Redirected after CF solve: {cur_url}")
-                                    break
-                            if login_completed:
-                                break
+                                cur_state = await tab.evaluate('''
+                                    (function() {
+                                        var text = document.body ? document.body.innerText : '';
+                                        var cf_active = text.includes('正在執行安全驗證') || 
+                                                        text.includes('請稍候') ||
+                                                        window.location.search.includes('__cf_chl_') ||
+                                                        !!window._cf_chl_opt;
+                                        return {
+                                            url: window.location.href,
+                                            cf_active: cf_active
+                                        };
+                                    })()
+                                ''')
+                                cur_state = util.parse_nodriver_result(cur_state)
+                                if isinstance(cur_state, dict):
+                                    cur_url = cur_state.get('url', '')
+                                    cf_active = cur_state.get('cf_active', True)
+                                    if not cf_active:
+                                        if '/users/sign_in' not in cur_url:
+                                            login_completed = True
+                                            debug.log(f"[KKTIX SIGNIN] Redirected after CF solve: {cur_url}")
+                                        else:
+                                            debug.log("[KKTIX SIGNIN] CF clearance passed, returned to sign_in to submit credentials")
+                                        break
+                            break  # Exit attempt loop so nodriver_kktix_signin can cleanly handle the new state
                 except Exception as exc:
                     # Report the first failure with its attempt index, then only
                     # the summary below; printing every attempt floods the log.

--- a/src/platforms/kktix.py
+++ b/src/platforms/kktix.py
@@ -134,6 +134,52 @@ async def nodriver_kktix_check_queue_page(tab, config_dict):
     return is_queue_page
 
 
+async def _get_kktix_submit_button_target(tab):
+    """Find clickable submit button on KKTIX login form and return its center coordinates (x, y) or None."""
+    submit_btn_info = await tab.evaluate('''
+        (function() {
+            const selectors = [
+                'form#new_user input[type="submit"]',
+                'form[action*="sign_in"] input[type="submit"]',
+                'input[type="submit"][value="登入"]',
+                'button[type="submit"]'
+            ];
+            for (const sel of selectors) {
+                const btn = document.querySelector(sel);
+                if (btn && !btn.disabled) {
+                    const r = btn.getBoundingClientRect();
+                    return { found: true, x: r.x + r.width / 2, y: r.y + r.height / 2 };
+                }
+            }
+            return { found: false };
+        })()
+    ''')
+    submit_btn_info = util.parse_nodriver_result(submit_btn_info)
+    if isinstance(submit_btn_info, dict) and submit_btn_info.get('found'):
+        return (submit_btn_info['x'], submit_btn_info['y'])
+    return None
+
+
+async def _get_kktix_login_error_message(tab):
+    """Detect login failure alert on KKTIX sign-in page for fast-fail."""
+    error_msg = await tab.evaluate('''
+        (function() {
+            const selectors = ['.alert.alert-danger', '#flash_alert', '.flash-alert', '.alert-error'];
+            for (const sel of selectors) {
+                const el = document.querySelector(sel);
+                if (el && el.innerText && el.innerText.trim().length > 0) {
+                    return el.innerText.trim();
+                }
+            }
+            return "";
+        })()
+    ''')
+    error_msg = util.parse_nodriver_result(error_msg)
+    if isinstance(error_msg, str) and len(error_msg.strip()) > 0:
+        return error_msg.strip()
+    return None
+
+
 async def nodriver_kktix_signin(tab, url, config_dict):
     # 函數開始時檢查暫停
     if await check_and_handle_pause(config_dict):
@@ -286,23 +332,11 @@ async def nodriver_kktix_signin(tab, url, config_dict):
                     return False
 
             # Click submit button via CDP to produce trusted native click (event.isTrusted = true)
-            submit_btn_info = await tab.evaluate('''
-                (function() {
-                    const btn = document.querySelector('form#new_user input[type="submit"]') ||
-                                document.querySelector('form[action*="sign_in"] input[type="submit"]') ||
-                                document.querySelector('input[type="submit"][value="登入"]') ||
-                                document.querySelector('button[type="submit"]');
-                    if (btn && !btn.disabled) {
-                        const r = btn.getBoundingClientRect();
-                        return { found: true, x: r.x + r.width / 2, y: r.y + r.height / 2 };
-                    }
-                    return { found: false };
-                })()
-            ''')
-            submit_btn_info = util.parse_nodriver_result(submit_btn_info)
-            if isinstance(submit_btn_info, dict) and submit_btn_info.get('found'):
-                debug.log(f"[KKTIX SIGNIN] Submit clicked via CDP at ({submit_btn_info['x']:.0f}, {submit_btn_info['y']:.0f})")
-                await cdp_click(tab, submit_btn_info['x'], submit_btn_info['y'])
+            submit_target = await _get_kktix_submit_button_target(tab)
+            if submit_target:
+                target_x, target_y = submit_target
+                debug.log(f"[KKTIX SIGNIN] Submit clicked via CDP at ({target_x:.0f}, {target_y:.0f})")
+                await cdp_click(tab, target_x, target_y)
             else:
                 debug.log("[KKTIX SIGNIN] No clickable submit button found; locale may differ or form not rendered")
                 return False
@@ -335,6 +369,13 @@ async def nodriver_kktix_signin(tab, url, config_dict):
                         debug.log(f"[KKTIX SIGNIN] Login completed after {attempt * check_interval:.1f}s, redirected to: {current_url}")
                         has_redirected = True
                         break
+
+                    # Fast-Fail: Check if page reported invalid credentials
+                    if attempt >= 2 and current_url and is_kktix_login_page(current_url):
+                        login_error = await _get_kktix_login_error_message(tab)
+                        if login_error:
+                            debug.log(f"[KKTIX SIGNIN ERROR] Login failed with message: '{login_error}'")
+                            return False
                 except Exception as exc:
                     url_error_count += 1
                     last_url_exc = str(exc)


### PR DESCRIPTION
## 變更摘要

修復 KKTIX 購票流程中，自動登入時卡在 Cloudflare Turnstile 驗證以及表單提交後中繼頁（「請稍候... / Just a moment...」）無限等待的卡死問題，並重構提升登入流程的響應速度與穩定性。

### 主要修正與優化內容：
1. **修復 Cloudflare 中繼頁指紋檢測卡死 (Transit Page Hang)**：
   - 移除 `get_nodriver_browser_args()` 中 19 個過時且容易被 Cloudflare 識別為 Headless 特徵的 CLI flags，改採 Zendriver 原生優化的核心參數配置並加入 `--lang=zh-TW`，徹底解決表單提交後停在「請稍候...」無法跳轉的問題。
2. **原生 CDP 座標點擊 (`isTrusted = true`)**：
   - 使用 DOM Pierce 穿透取得 Turnstile iframe 座標，透過 CDP 發送自然軌跡微延遲滑鼠事件（`mouseMoved` -> `mousePressed` -> `mouseReleased`），在 0.5s 內順利取回 Token。
   - 登入提交按鈕改採 CDP 座標點擊，確保 `event.isTrusted = true` 通過前端表單防護檢驗。
3. **移除中繼頁破壞性攔截與無效等待**：
   - 移除登入後輪詢時過早觸發的挑戰攔截邏輯（原邏輯會在跳轉中途重新點擊或刷新，破壞 in-flight HTTP 302 導向）。
   - 在主迴圈加入 `is_kktix_login_page` 判斷，避免全域檢測將登入表單上的嵌入式 Turnstile 誤判為全頁面阻擋。
4. **消除登入前重複導向與 Session 狀態污染**：
   - 優化 `nodriver_goto_homepage()`：若已配置 KKTIX 帳號，啟動時直接導向登入頁（帶 `back_to` 參數），避免先載入活動頁產生訪客 Session 影響登入後狀態。
5. **極速失敗防護機制 (Fast-Fail)**：
   - 新增 `_get_kktix_login_error_message()`：在輪詢時主動偵測 `.alert.alert-danger`、`#flash_alert`（如帳號或密碼錯誤），可在 1 秒內即時退出並報警，無需枯等 20 秒超時。
6. **語意化重構與顯式匯入 (Clean Code)**：
   - 將提交按鈕查找邏輯封裝為語意化函數 `_get_kktix_submit_button_target()`。
   - 將 `nodriver_tixcraft.py` 對 `platforms.kktix` 的萬用字元匯入改為顯式具名匯入，消除全域命名空間污染。

## 變更類型

- [ ] ✨ 新功能 (feat)
- [x] 🐛 Bug 修復 (fix)
- [x] ♻️ 重構 (refactor)
- [ ] 📝 文件更新 (docs)
- [ ] 🔧 維護 (chore)

## 影響平台

**台灣**
- [ ] TixCraft / TicketMaster / Teamear / Indievox
- [x] KKTIX
- [ ] iBon / 年代售票
- [ ] TicketPlus
- [ ] FamiTicket
- [ ] 寬宏售票（KHAM）
- [ ] FANSI GO
- [ ] FunOne

**海外**
- [ ] Cityline 買飛
- [ ] HKTicketing 快達票

**通用**
- [x] 跨平台共用功能（nodriver_common / util / settings）

## 檢查清單

- [x] 已測試功能正常
- [x] 無敏感資訊（密碼、Cookie、API key）
- [x] `.py` 檔案中沒有使用 emoji

## 測試紀錄

- **實測環境**：Windows 11, Chrome, Python 3.10 / Zendriver
- **端到端流程實測**：
  1. 瀏覽器啟動直達 `https://kktix.com/users/sign_in?back_to=...`
  2. 自動填入帳號與密碼
  3. CDP 精準點擊 Turnstile Checkbox，0.5s 內確認取得 Token (`len=773`)
  4. CDP 原生點擊「登入」按鈕，2.0s 內順利通過 Cloudflare 中繼頁並成功跳轉回活動售票頁
  5. 自動執行票種選擇、填入數量、點擊「電腦配位」
  6. 成功抵達訂單結帳頁面（`Ticket purchase completed`）
- **編譯打包驗證**：
  - PyInstaller 順利完成編譯
  - 產出之 `nodriver_tixcraft.exe` 經實機測試確認全流程正常無誤。